### PR TITLE
Add core-v-verif repository for Thales

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ cve2       | [cve2](https://github.com/openhwgroup/cve2) | WI2.2.5, WI2.2.8, WI2
 TimeWeaver | [absint.com/timeweaver](https://www.absint.com/timeweaver/) | WI4.1.5 | AbsInt | Waiting for WI4.1.3 / WI2.2.1 | proprietary |
 CompCert   | [github.com/AbsInt/CompCert](https://github.com/AbsInt/CompCert) | WI4.2.4 | AbsInt | Waiting for WI2.5.4 | dual licensed (see repository) |
 CVA6       | [cva6](https://github.com/openhwgroup/cva6) | WI2.4.1, WI2.4.2, WI2.4.3, WI2.4.5 | Thales, Sysgo, TU Darmstadt, Bosch  | Design and Verification in progress | Solderpad |
+UVM env for RISC-V verif | [core-v-verif](https://github.com/openhwgroup/core-v-verif) | WI2.4.1 | Thales | CVA6 verification in progress | Solderpad |
 Yocto for CVA6 | [meta-cva6-yocto](https://github.com/openhwgroup/meta-cva6-yocto) | WI4.3.3 | Thales | Initial release | MIT |
 Setting up Yocto and baremetal debug on CVA6 | [cva6-eclipse-demo](https://github.com/ThalesGroup/cva6-eclipse-demo) | WI4.3.3 |Thales | Initial release | Apache |
 CLIC       | [clic](https://github.com/pulp-platform/clic) | WI3.1.7 | ETH | Design and Verification in progress | Apache-2.0 |


### PR DESCRIPTION
To verify CVA6 core-v-verif contains UVM env.