### PR TITLE
Fix for the WI list of the Kactus2 project entry (TRISTAN)

### DIFF
--- a/ips/tristan.tools.json
+++ b/ips/tristan.tools.json
@@ -116,7 +116,7 @@
         "Status": "Released",
         "Description": "IP-XACT/Kactus2 generator for the Renode simulator platform​​​",
         "Project": "TRISTAN",
-        "WI": "WI5.2.9, WI5.3.3",
+        "WI": ["WI5.2.9", "WI5.3.3"],
         "Partners": "MINRES Technologies, Tampere University",
         "Comment": "Used by: Tampere University, Nokia, Cargotec"
     },


### PR DESCRIPTION
Making the WI list as a proper JSON array for the Kactus2 project entry (TRISTAN)

Noting that all TRISTAN JSON files should probably be merged into a single `tristan.json`, following the current discussions on the Virtual Repository format.