### PR TITLE
Update on existing features

### DIFF
--- a/cfg/categories.json
+++ b/cfg/categories.json
@@ -76,12 +76,8 @@
     "aliases": ["SBST"]
   },
   {
-    "name": "Self-Test & Test",
-    "aliases": []
-  },
-  {
-    "name": "Design Specific Language (DSL)",
-    "aliases": []
+    "name": "Design Specific Language",
+    "aliases": ["DSL"]
   },
   {
     "name": "Software Library",
@@ -89,10 +85,6 @@
   },
   {
     "name": "Chip Integration",
-    "aliases": []
-  },
-  {
-    "name": "Subsystem",
     "aliases": []
   },
   {
@@ -106,5 +98,17 @@
   {
     "name": "Security",
     "aliases": []
+  },
+  {
+    "name": "Vector Processor Unit",
+    "aliases": ["VPU"]
+  },
+  {
+    "name": "Timing Analysis software",
+    "aliases": [""]
+  },
+  {
+    "name": "Others",
+    "aliases": [""]
   }
 ]

--- a/cfg/licenses.json
+++ b/cfg/licenses.json
@@ -1,0 +1,2918 @@
+[
+  {
+    "name": "BSD Zero Clause License",
+    "licenseId": "0BSD"
+  },
+  {
+    "name": "3D Slicer License v1.0",
+    "licenseId": "3D-Slicer-1.0"
+  },
+  {
+    "name": "Attribution Assurance License",
+    "licenseId": "AAL"
+  },
+  {
+    "name": "Amazon Digital Services License",
+    "licenseId": "ADSL"
+  },
+  {
+    "name": "Academic Free License v1.1",
+    "licenseId": "AFL-1.1"
+  },
+  {
+    "name": "Academic Free License v1.2",
+    "licenseId": "AFL-1.2"
+  },
+  {
+    "name": "Academic Free License v2.0",
+    "licenseId": "AFL-2.0"
+  },
+  {
+    "name": "Academic Free License v2.1",
+    "licenseId": "AFL-2.1"
+  },
+  {
+    "name": "Academic Free License v3.0",
+    "licenseId": "AFL-3.0"
+  },
+  {
+    "name": "Affero General Public License v1.0",
+    "licenseId": "AGPL-1.0"
+  },
+  {
+    "name": "Affero General Public License v1.0 only",
+    "licenseId": "AGPL-1.0-only"
+  },
+  {
+    "name": "Affero General Public License v1.0 or later",
+    "licenseId": "AGPL-1.0-or-later"
+  },
+  {
+    "name": "GNU Affero General Public License v3.0",
+    "licenseId": "AGPL-3.0"
+  },
+  {
+    "name": "GNU Affero General Public License v3.0 only",
+    "licenseId": "AGPL-3.0-only"
+  },
+  {
+    "name": "GNU Affero General Public License v3.0 or later",
+    "licenseId": "AGPL-3.0-or-later"
+  },
+  {
+    "name": "ALGLIB Documentation License",
+    "licenseId": "ALGLIB-Documentation"
+  },
+  {
+    "name": "AMD newlib License",
+    "licenseId": "AMD-newlib"
+  },
+  {
+    "name": "AMD's plpa_map.c License",
+    "licenseId": "AMDPLPA"
+  },
+  {
+    "name": "Apple MIT License",
+    "licenseId": "AML"
+  },
+  {
+    "name": "AML glslang variant License",
+    "licenseId": "AML-glslang"
+  },
+  {
+    "name": "Academy of Motion Picture Arts and Sciences BSD",
+    "licenseId": "AMPAS"
+  },
+  {
+    "name": "ANTLR Software Rights Notice",
+    "licenseId": "ANTLR-PD"
+  },
+  {
+    "name": "ANTLR Software Rights Notice with license fallback",
+    "licenseId": "ANTLR-PD-fallback"
+  },
+  {
+    "name": "Adobe Postscript AFM License",
+    "licenseId": "APAFML"
+  },
+  {
+    "name": "Adaptive Public License 1.0",
+    "licenseId": "APL-1.0"
+  },
+  {
+    "name": "Apple Public Source License 1.0",
+    "licenseId": "APSL-1.0"
+  },
+  {
+    "name": "Apple Public Source License 1.1",
+    "licenseId": "APSL-1.1"
+  },
+  {
+    "name": "Apple Public Source License 1.2",
+    "licenseId": "APSL-1.2"
+  },
+  {
+    "name": "Apple Public Source License 2.0",
+    "licenseId": "APSL-2.0"
+  },
+  {
+    "name": "ASWF Digital Assets License version 1.0",
+    "licenseId": "ASWF-Digital-Assets-1.0"
+  },
+  {
+    "name": "ASWF Digital Assets License 1.1",
+    "licenseId": "ASWF-Digital-Assets-1.1"
+  },
+  {
+    "name": "Abstyles License",
+    "licenseId": "Abstyles"
+  },
+  {
+    "name": "AdaCore Doc License",
+    "licenseId": "AdaCore-doc"
+  },
+  {
+    "name": "Adobe Systems Incorporated Source Code License Agreement",
+    "licenseId": "Adobe-2006"
+  },
+  {
+    "name": "Adobe Display PostScript License",
+    "licenseId": "Adobe-Display-PostScript"
+  },
+  {
+    "name": "Adobe Glyph List License",
+    "licenseId": "Adobe-Glyph"
+  },
+  {
+    "name": "Adobe Utopia Font License",
+    "licenseId": "Adobe-Utopia"
+  },
+  {
+    "name": "Advanced Cryptics Dictionary License",
+    "licenseId": "Advanced-Cryptics-Dictionary"
+  },
+  {
+    "name": "Afmparse License",
+    "licenseId": "Afmparse"
+  },
+  {
+    "name": "Aladdin Free Public License",
+    "licenseId": "Aladdin"
+  },
+  {
+    "name": "Apache License 1.0",
+    "licenseId": "Apache-1.0"
+  },
+  {
+    "name": "Apache License 1.1",
+    "licenseId": "Apache-1.1"
+  },
+  {
+    "name": "Apache License 2.0",
+    "licenseId": "Apache-2.0"
+  },
+  {
+    "name": "App::s2p License",
+    "licenseId": "App-s2p"
+  },
+  {
+    "name": "Arphic Public License",
+    "licenseId": "Arphic-1999"
+  },
+  {
+    "name": "Artistic License 1.0",
+    "licenseId": "Artistic-1.0"
+  },
+  {
+    "name": "Artistic License 1.0 (Perl)",
+    "licenseId": "Artistic-1.0-Perl"
+  },
+  {
+    "name": "Artistic License 1.0 w/clause 8",
+    "licenseId": "Artistic-1.0-cl8"
+  },
+  {
+    "name": "Artistic License 2.0",
+    "licenseId": "Artistic-2.0"
+  },
+  {
+    "name": "Artistic License 1.0 (dist)",
+    "licenseId": "Artistic-dist"
+  },
+  {
+    "name": "Aspell Russian License",
+    "licenseId": "Aspell-RU"
+  },
+  {
+    "name": "Buena Onda License Agreement v1.1",
+    "licenseId": "BOLA-1.1"
+  },
+  {
+    "name": "BSD 1-Clause License",
+    "licenseId": "BSD-1-Clause"
+  },
+  {
+    "name": "BSD 2-Clause \"Simplified\" License",
+    "licenseId": "BSD-2-Clause"
+  },
+  {
+    "name": "BSD 2-Clause - Ian Darwin variant",
+    "licenseId": "BSD-2-Clause-Darwin"
+  },
+  {
+    "name": "BSD 2-Clause FreeBSD License",
+    "licenseId": "BSD-2-Clause-FreeBSD"
+  },
+  {
+    "name": "BSD 2-Clause NetBSD License",
+    "licenseId": "BSD-2-Clause-NetBSD"
+  },
+  {
+    "name": "BSD-2-Clause Plus Patent License",
+    "licenseId": "BSD-2-Clause-Patent"
+  },
+  {
+    "name": "BSD 2-Clause with views sentence",
+    "licenseId": "BSD-2-Clause-Views"
+  },
+  {
+    "name": "BSD 2-Clause - first lines requirement",
+    "licenseId": "BSD-2-Clause-first-lines"
+  },
+  {
+    "name": "BSD 2-Clause pkgconf disclaimer variant",
+    "licenseId": "BSD-2-Clause-pkgconf-disclaimer"
+  },
+  {
+    "name": "BSD 3-Clause \"New\" or \"Revised\" License",
+    "licenseId": "BSD-3-Clause"
+  },
+  {
+    "name": "BSD with attribution",
+    "licenseId": "BSD-3-Clause-Attribution"
+  },
+  {
+    "name": "BSD 3-Clause Clear License",
+    "licenseId": "BSD-3-Clause-Clear"
+  },
+  {
+    "name": "Hewlett-Packard BSD variant license",
+    "licenseId": "BSD-3-Clause-HP"
+  },
+  {
+    "name": "Lawrence Berkeley National Labs BSD variant license",
+    "licenseId": "BSD-3-Clause-LBNL"
+  },
+  {
+    "name": "BSD 3-Clause Modification",
+    "licenseId": "BSD-3-Clause-Modification"
+  },
+  {
+    "name": "BSD 3-Clause No Military License",
+    "licenseId": "BSD-3-Clause-No-Military-License"
+  },
+  {
+    "name": "BSD 3-Clause No Nuclear License",
+    "licenseId": "BSD-3-Clause-No-Nuclear-License"
+  },
+  {
+    "name": "BSD 3-Clause No Nuclear License 2014",
+    "licenseId": "BSD-3-Clause-No-Nuclear-License-2014"
+  },
+  {
+    "name": "BSD 3-Clause No Nuclear Warranty",
+    "licenseId": "BSD-3-Clause-No-Nuclear-Warranty"
+  },
+  {
+    "name": "BSD 3-Clause Open MPI variant",
+    "licenseId": "BSD-3-Clause-Open-MPI"
+  },
+  {
+    "name": "BSD 3-Clause Sun Microsystems",
+    "licenseId": "BSD-3-Clause-Sun"
+  },
+  {
+    "name": "BSD 3-Clause Tso variant",
+    "licenseId": "BSD-3-Clause-Tso"
+  },
+  {
+    "name": "BSD 3-Clause acpica variant",
+    "licenseId": "BSD-3-Clause-acpica"
+  },
+  {
+    "name": "BSD 3-Clause Flex variant",
+    "licenseId": "BSD-3-Clause-flex"
+  },
+  {
+    "name": "BSD 4-Clause \"Original\" or \"Old\" License",
+    "licenseId": "BSD-4-Clause"
+  },
+  {
+    "name": "BSD 4 Clause Shortened",
+    "licenseId": "BSD-4-Clause-Shortened"
+  },
+  {
+    "name": "BSD-4-Clause (University of California-Specific)",
+    "licenseId": "BSD-4-Clause-UC"
+  },
+  {
+    "name": "BSD 4.3 RENO License",
+    "licenseId": "BSD-4.3RENO"
+  },
+  {
+    "name": "BSD 4.3 TAHOE License",
+    "licenseId": "BSD-4.3TAHOE"
+  },
+  {
+    "name": "BSD Advertising Acknowledgement License",
+    "licenseId": "BSD-Advertising-Acknowledgement"
+  },
+  {
+    "name": "BSD with Attribution and HPND disclaimer",
+    "licenseId": "BSD-Attribution-HPND-disclaimer"
+  },
+  {
+    "name": "BSD-Inferno-Nettverk",
+    "licenseId": "BSD-Inferno-Nettverk"
+  },
+  {
+    "name": "BSD Mark Modifications License",
+    "licenseId": "BSD-Mark-Modifications"
+  },
+  {
+    "name": "BSD Protection License",
+    "licenseId": "BSD-Protection"
+  },
+  {
+    "name": "BSD Source Code Attribution",
+    "licenseId": "BSD-Source-Code"
+  },
+  {
+    "name": "BSD Source Code Attribution - beginning of file variant",
+    "licenseId": "BSD-Source-beginning-file"
+  },
+  {
+    "name": "Systemics BSD variant license",
+    "licenseId": "BSD-Systemics"
+  },
+  {
+    "name": "Systemics W3Works BSD variant license",
+    "licenseId": "BSD-Systemics-W3Works"
+  },
+  {
+    "name": "Boost Software License 1.0",
+    "licenseId": "BSL-1.0"
+  },
+  {
+    "name": "Business Source License 1.1",
+    "licenseId": "BUSL-1.1"
+  },
+  {
+    "name": "Baekmuk License",
+    "licenseId": "Baekmuk"
+  },
+  {
+    "name": "Bahyph License",
+    "licenseId": "Bahyph"
+  },
+  {
+    "name": "Barr License",
+    "licenseId": "Barr"
+  },
+  {
+    "name": "Beerware License",
+    "licenseId": "Beerware"
+  },
+  {
+    "name": "BitTorrent Open Source License v1.0",
+    "licenseId": "BitTorrent-1.0"
+  },
+  {
+    "name": "BitTorrent Open Source License v1.1",
+    "licenseId": "BitTorrent-1.1"
+  },
+  {
+    "name": "Bitstream Charter Font License",
+    "licenseId": "Bitstream-Charter"
+  },
+  {
+    "name": "Bitstream Vera Font License",
+    "licenseId": "Bitstream-Vera"
+  },
+  {
+    "name": "Blue Oak Model License 1.0.0",
+    "licenseId": "BlueOak-1.0.0"
+  },
+  {
+    "name": "Boehm-Demers-Weiser GC License",
+    "licenseId": "Boehm-GC"
+  },
+  {
+    "name": "Boehm-Demers-Weiser GC License (without fee)",
+    "licenseId": "Boehm-GC-without-fee"
+  },
+  {
+    "name": "Borceux license",
+    "licenseId": "Borceux"
+  },
+  {
+    "name": "Brian Gladman 2-Clause License",
+    "licenseId": "Brian-Gladman-2-Clause"
+  },
+  {
+    "name": "Brian Gladman 3-Clause License",
+    "licenseId": "Brian-Gladman-3-Clause"
+  },
+  {
+    "name": "Buddy License",
+    "licenseId": "Buddy"
+  },
+  {
+    "name": "Computational Use of Data Agreement v1.0",
+    "licenseId": "C-UDA-1.0"
+  },
+  {
+    "name": "Cryptographic Autonomy License 1.0",
+    "licenseId": "CAL-1.0"
+  },
+  {
+    "name": "Cryptographic Autonomy License 1.0 (Combined Work Exception)",
+    "licenseId": "CAL-1.0-Combined-Work-Exception"
+  },
+  {
+    "name": "Common Attack    Pattern Enumeration and Classification License",
+    "licenseId": "CAPEC-tou"
+  },
+  {
+    "name": "Computer Associates Trusted Open Source License 1.1",
+    "licenseId": "CATOSL-1.1"
+  },
+  {
+    "name": "Creative Commons Attribution 1.0 Generic",
+    "licenseId": "CC-BY-1.0"
+  },
+  {
+    "name": "Creative Commons Attribution 2.0 Generic",
+    "licenseId": "CC-BY-2.0"
+  },
+  {
+    "name": "Creative Commons Attribution 2.5 Generic",
+    "licenseId": "CC-BY-2.5"
+  },
+  {
+    "name": "Creative Commons Attribution 2.5 Australia",
+    "licenseId": "CC-BY-2.5-AU"
+  },
+  {
+    "name": "Creative Commons Attribution 3.0 Unported",
+    "licenseId": "CC-BY-3.0"
+  },
+  {
+    "name": "Creative Commons Attribution 3.0 Austria",
+    "licenseId": "CC-BY-3.0-AT"
+  },
+  {
+    "name": "Creative Commons Attribution 3.0 Australia",
+    "licenseId": "CC-BY-3.0-AU"
+  },
+  {
+    "name": "Creative Commons Attribution 3.0 Germany",
+    "licenseId": "CC-BY-3.0-DE"
+  },
+  {
+    "name": "Creative Commons Attribution 3.0 IGO",
+    "licenseId": "CC-BY-3.0-IGO"
+  },
+  {
+    "name": "Creative Commons Attribution 3.0 Netherlands",
+    "licenseId": "CC-BY-3.0-NL"
+  },
+  {
+    "name": "Creative Commons Attribution 3.0 United States",
+    "licenseId": "CC-BY-3.0-US"
+  },
+  {
+    "name": "Creative Commons Attribution 4.0 International",
+    "licenseId": "CC-BY-4.0"
+  },
+  {
+    "name": "Creative Commons Attribution Non Commercial 1.0 Generic",
+    "licenseId": "CC-BY-NC-1.0"
+  },
+  {
+    "name": "Creative Commons Attribution Non Commercial 2.0 Generic",
+    "licenseId": "CC-BY-NC-2.0"
+  },
+  {
+    "name": "Creative Commons Attribution Non Commercial 2.5 Generic",
+    "licenseId": "CC-BY-NC-2.5"
+  },
+  {
+    "name": "Creative Commons Attribution Non Commercial 3.0 Unported",
+    "licenseId": "CC-BY-NC-3.0"
+  },
+  {
+    "name": "Creative Commons Attribution Non Commercial 3.0 Germany",
+    "licenseId": "CC-BY-NC-3.0-DE"
+  },
+  {
+    "name": "Creative Commons Attribution Non Commercial 4.0 International",
+    "licenseId": "CC-BY-NC-4.0"
+  },
+  {
+    "name": "Creative Commons Attribution Non Commercial No Derivatives 1.0 Generic",
+    "licenseId": "CC-BY-NC-ND-1.0"
+  },
+  {
+    "name": "Creative Commons Attribution Non Commercial No Derivatives 2.0 Generic",
+    "licenseId": "CC-BY-NC-ND-2.0"
+  },
+  {
+    "name": "Creative Commons Attribution Non Commercial No Derivatives 2.5 Generic",
+    "licenseId": "CC-BY-NC-ND-2.5"
+  },
+  {
+    "name": "Creative Commons Attribution Non Commercial No Derivatives 3.0 Unported",
+    "licenseId": "CC-BY-NC-ND-3.0"
+  },
+  {
+    "name": "Creative Commons Attribution Non Commercial No Derivatives 3.0 Germany",
+    "licenseId": "CC-BY-NC-ND-3.0-DE"
+  },
+  {
+    "name": "Creative Commons Attribution Non Commercial No Derivatives 3.0 IGO",
+    "licenseId": "CC-BY-NC-ND-3.0-IGO"
+  },
+  {
+    "name": "Creative Commons Attribution Non Commercial No Derivatives 4.0 International",
+    "licenseId": "CC-BY-NC-ND-4.0"
+  },
+  {
+    "name": "Creative Commons Attribution Non Commercial Share Alike 1.0 Generic",
+    "licenseId": "CC-BY-NC-SA-1.0"
+  },
+  {
+    "name": "Creative Commons Attribution Non Commercial Share Alike 2.0 Generic",
+    "licenseId": "CC-BY-NC-SA-2.0"
+  },
+  {
+    "name": "Creative Commons Attribution Non Commercial Share Alike 2.0 Germany",
+    "licenseId": "CC-BY-NC-SA-2.0-DE"
+  },
+  {
+    "name": "Creative Commons Attribution-NonCommercial-ShareAlike 2.0 France",
+    "licenseId": "CC-BY-NC-SA-2.0-FR"
+  },
+  {
+    "name": "Creative Commons Attribution Non Commercial Share Alike 2.0 England and Wales",
+    "licenseId": "CC-BY-NC-SA-2.0-UK"
+  },
+  {
+    "name": "Creative Commons Attribution Non Commercial Share Alike 2.5 Generic",
+    "licenseId": "CC-BY-NC-SA-2.5"
+  },
+  {
+    "name": "Creative Commons Attribution Non Commercial Share Alike 3.0 Unported",
+    "licenseId": "CC-BY-NC-SA-3.0"
+  },
+  {
+    "name": "Creative Commons Attribution Non Commercial Share Alike 3.0 Germany",
+    "licenseId": "CC-BY-NC-SA-3.0-DE"
+  },
+  {
+    "name": "Creative Commons Attribution Non Commercial Share Alike 3.0 IGO",
+    "licenseId": "CC-BY-NC-SA-3.0-IGO"
+  },
+  {
+    "name": "Creative Commons Attribution Non Commercial Share Alike 4.0 International",
+    "licenseId": "CC-BY-NC-SA-4.0"
+  },
+  {
+    "name": "Creative Commons Attribution No Derivatives 1.0 Generic",
+    "licenseId": "CC-BY-ND-1.0"
+  },
+  {
+    "name": "Creative Commons Attribution No Derivatives 2.0 Generic",
+    "licenseId": "CC-BY-ND-2.0"
+  },
+  {
+    "name": "Creative Commons Attribution No Derivatives 2.5 Generic",
+    "licenseId": "CC-BY-ND-2.5"
+  },
+  {
+    "name": "Creative Commons Attribution No Derivatives 3.0 Unported",
+    "licenseId": "CC-BY-ND-3.0"
+  },
+  {
+    "name": "Creative Commons Attribution No Derivatives 3.0 Germany",
+    "licenseId": "CC-BY-ND-3.0-DE"
+  },
+  {
+    "name": "Creative Commons Attribution No Derivatives 4.0 International",
+    "licenseId": "CC-BY-ND-4.0"
+  },
+  {
+    "name": "Creative Commons Attribution Share Alike 1.0 Generic",
+    "licenseId": "CC-BY-SA-1.0"
+  },
+  {
+    "name": "Creative Commons Attribution Share Alike 2.0 Generic",
+    "licenseId": "CC-BY-SA-2.0"
+  },
+  {
+    "name": "Creative Commons Attribution Share Alike 2.0 England and Wales",
+    "licenseId": "CC-BY-SA-2.0-UK"
+  },
+  {
+    "name": "Creative Commons Attribution Share Alike 2.1 Japan",
+    "licenseId": "CC-BY-SA-2.1-JP"
+  },
+  {
+    "name": "Creative Commons Attribution Share Alike 2.5 Generic",
+    "licenseId": "CC-BY-SA-2.5"
+  },
+  {
+    "name": "Creative Commons Attribution Share Alike 3.0 Unported",
+    "licenseId": "CC-BY-SA-3.0"
+  },
+  {
+    "name": "Creative Commons Attribution Share Alike 3.0 Austria",
+    "licenseId": "CC-BY-SA-3.0-AT"
+  },
+  {
+    "name": "Creative Commons Attribution Share Alike 3.0 Germany",
+    "licenseId": "CC-BY-SA-3.0-DE"
+  },
+  {
+    "name": "Creative Commons Attribution-ShareAlike 3.0 IGO",
+    "licenseId": "CC-BY-SA-3.0-IGO"
+  },
+  {
+    "name": "Creative Commons Attribution Share Alike 4.0 International",
+    "licenseId": "CC-BY-SA-4.0"
+  },
+  {
+    "name": "Creative Commons Public Domain Dedication and Certification",
+    "licenseId": "CC-PDDC"
+  },
+  {
+    "name": "Creative    Commons Public Domain Mark 1.0 Universal",
+    "licenseId": "CC-PDM-1.0"
+  },
+  {
+    "name": "Creative Commons Share Alike 1.0 Generic",
+    "licenseId": "CC-SA-1.0"
+  },
+  {
+    "name": "Creative Commons Zero v1.0 Universal",
+    "licenseId": "CC0-1.0"
+  },
+  {
+    "name": "Common Development and Distribution License 1.0",
+    "licenseId": "CDDL-1.0"
+  },
+  {
+    "name": "Common Development and Distribution License 1.1",
+    "licenseId": "CDDL-1.1"
+  },
+  {
+    "name": "Common Documentation License 1.0",
+    "licenseId": "CDL-1.0"
+  },
+  {
+    "name": "Community Data License Agreement Permissive 1.0",
+    "licenseId": "CDLA-Permissive-1.0"
+  },
+  {
+    "name": "Community Data License Agreement Permissive 2.0",
+    "licenseId": "CDLA-Permissive-2.0"
+  },
+  {
+    "name": "Community Data License Agreement Sharing 1.0",
+    "licenseId": "CDLA-Sharing-1.0"
+  },
+  {
+    "name": "CeCILL Free Software License Agreement v1.0",
+    "licenseId": "CECILL-1.0"
+  },
+  {
+    "name": "CeCILL Free Software License Agreement v1.1",
+    "licenseId": "CECILL-1.1"
+  },
+  {
+    "name": "CeCILL Free Software License Agreement v2.0",
+    "licenseId": "CECILL-2.0"
+  },
+  {
+    "name": "CeCILL Free Software License Agreement v2.1",
+    "licenseId": "CECILL-2.1"
+  },
+  {
+    "name": "CeCILL-B Free Software License Agreement",
+    "licenseId": "CECILL-B"
+  },
+  {
+    "name": "CeCILL-C Free Software License Agreement",
+    "licenseId": "CECILL-C"
+  },
+  {
+    "name": "CERN Open Hardware Licence v1.1",
+    "licenseId": "CERN-OHL-1.1"
+  },
+  {
+    "name": "CERN Open Hardware Licence v1.2",
+    "licenseId": "CERN-OHL-1.2"
+  },
+  {
+    "name": "CERN Open Hardware Licence Version 2 - Permissive",
+    "licenseId": "CERN-OHL-P-2.0"
+  },
+  {
+    "name": "CERN Open Hardware Licence Version 2 - Strongly Reciprocal",
+    "licenseId": "CERN-OHL-S-2.0"
+  },
+  {
+    "name": "CERN Open Hardware Licence Version 2 - Weakly Reciprocal",
+    "licenseId": "CERN-OHL-W-2.0"
+  },
+  {
+    "name": "CFITSIO License",
+    "licenseId": "CFITSIO"
+  },
+  {
+    "name": "CMU Mach License",
+    "licenseId": "CMU-Mach"
+  },
+  {
+    "name": "CMU    Mach - no notices-in-documentation variant",
+    "licenseId": "CMU-Mach-nodoc"
+  },
+  {
+    "name": "CNRI Jython License",
+    "licenseId": "CNRI-Jython"
+  },
+  {
+    "name": "CNRI Python License",
+    "licenseId": "CNRI-Python"
+  },
+  {
+    "name": "CNRI Python Open Source GPL Compatible License Agreement",
+    "licenseId": "CNRI-Python-GPL-Compatible"
+  },
+  {
+    "name": "Copyfree Open Innovation License",
+    "licenseId": "COIL-1.0"
+  },
+  {
+    "name": "Common Public Attribution License 1.0",
+    "licenseId": "CPAL-1.0"
+  },
+  {
+    "name": "Common Public License 1.0",
+    "licenseId": "CPL-1.0"
+  },
+  {
+    "name": "Code Project Open License 1.02",
+    "licenseId": "CPOL-1.02"
+  },
+  {
+    "name": "CUA Office Public License v1.0",
+    "licenseId": "CUA-OPL-1.0"
+  },
+  {
+    "name": "Caldera License",
+    "licenseId": "Caldera"
+  },
+  {
+    "name": "Caldera License (without preamble)",
+    "licenseId": "Caldera-no-preamble"
+  },
+  {
+    "name": "Catharon License",
+    "licenseId": "Catharon"
+  },
+  {
+    "name": "Clarified Artistic License",
+    "licenseId": "ClArtistic"
+  },
+  {
+    "name": "Clips License",
+    "licenseId": "Clips"
+  },
+  {
+    "name": "Community Specification License 1.0",
+    "licenseId": "Community-Spec-1.0"
+  },
+  {
+    "name": "Condor Public License v1.1",
+    "licenseId": "Condor-1.1"
+  },
+  {
+    "name": "Cornell Lossless JPEG License",
+    "licenseId": "Cornell-Lossless-JPEG"
+  },
+  {
+    "name": "Cronyx License",
+    "licenseId": "Cronyx"
+  },
+  {
+    "name": "Crossword License",
+    "licenseId": "Crossword"
+  },
+  {
+    "name": "CryptoSwift License",
+    "licenseId": "CryptoSwift"
+  },
+  {
+    "name": "CrystalStacker License",
+    "licenseId": "CrystalStacker"
+  },
+  {
+    "name": "Cube License",
+    "licenseId": "Cube"
+  },
+  {
+    "name": "Deutsche Freie Software Lizenz",
+    "licenseId": "D-FSL-1.0"
+  },
+  {
+    "name": "DEC 3-Clause License",
+    "licenseId": "DEC-3-Clause"
+  },
+  {
+    "name": "Data licence Germany – attribution – version 2.0",
+    "licenseId": "DL-DE-BY-2.0"
+  },
+  {
+    "name": "Data licence Germany – zero – version 2.0",
+    "licenseId": "DL-DE-ZERO-2.0"
+  },
+  {
+    "name": "DOC License",
+    "licenseId": "DOC"
+  },
+  {
+    "name": "Detection Rule License 1.0",
+    "licenseId": "DRL-1.0"
+  },
+  {
+    "name": "Detection Rule License 1.1",
+    "licenseId": "DRL-1.1"
+  },
+  {
+    "name": "DSDP License",
+    "licenseId": "DSDP"
+  },
+  {
+    "name": "DocBook DTD License",
+    "licenseId": "DocBook-DTD"
+  },
+  {
+    "name": "DocBook Schema License",
+    "licenseId": "DocBook-Schema"
+  },
+  {
+    "name": "DocBook Stylesheet License",
+    "licenseId": "DocBook-Stylesheet"
+  },
+  {
+    "name": "DocBook XML License",
+    "licenseId": "DocBook-XML"
+  },
+  {
+    "name": "Dotseqn License",
+    "licenseId": "Dotseqn"
+  },
+  {
+    "name": "Educational Community License v1.0",
+    "licenseId": "ECL-1.0"
+  },
+  {
+    "name": "Educational Community License v2.0",
+    "licenseId": "ECL-2.0"
+  },
+  {
+    "name": "Eiffel Forum License v1.0",
+    "licenseId": "EFL-1.0"
+  },
+  {
+    "name": "Eiffel Forum License v2.0",
+    "licenseId": "EFL-2.0"
+  },
+  {
+    "name": "EPICS Open License",
+    "licenseId": "EPICS"
+  },
+  {
+    "name": "Eclipse Public License 1.0",
+    "licenseId": "EPL-1.0"
+  },
+  {
+    "name": "Eclipse Public License 2.0",
+    "licenseId": "EPL-2.0"
+  },
+  {
+    "name": "European Space Agency Public License – v2.4 – Permissive (Type 3)",
+    "licenseId": "ESA-PL-permissive-2.4"
+  },
+  {
+    "name": "European Space Agency Public License (ESA-PL) - V2.4 - Strong Copyleft (Type 1)",
+    "licenseId": "ESA-PL-strong-copyleft-2.4"
+  },
+  {
+    "name": "European Space Agency Public License – v2.4 – Weak Copyleft (Type 2)",
+    "licenseId": "ESA-PL-weak-copyleft-2.4"
+  },
+  {
+    "name": "EU DataGrid Software License",
+    "licenseId": "EUDatagrid"
+  },
+  {
+    "name": "European Union Public License 1.0",
+    "licenseId": "EUPL-1.0"
+  },
+  {
+    "name": "European Union Public License 1.1",
+    "licenseId": "EUPL-1.1"
+  },
+  {
+    "name": "European Union Public License 1.2",
+    "licenseId": "EUPL-1.2"
+  },
+  {
+    "name": "Elastic License 2.0",
+    "licenseId": "Elastic-2.0"
+  },
+  {
+    "name": "Entessa Public License v1.0",
+    "licenseId": "Entessa"
+  },
+  {
+    "name": "Erlang Public License v1.1",
+    "licenseId": "ErlPL-1.1"
+  },
+  {
+    "name": "Eurosym License",
+    "licenseId": "Eurosym"
+  },
+  {
+    "name": "Fuzzy Bitmap License",
+    "licenseId": "FBM"
+  },
+  {
+    "name": "Fraunhofer FDK AAC Codec Library",
+    "licenseId": "FDK-AAC"
+  },
+  {
+    "name": "FSF All Permissive License",
+    "licenseId": "FSFAP"
+  },
+  {
+    "name": "FSF All Permissive License (without Warranty)",
+    "licenseId": "FSFAP-no-warranty-disclaimer"
+  },
+  {
+    "name": "FSF Unlimited License",
+    "licenseId": "FSFUL"
+  },
+  {
+    "name": "FSF Unlimited License (with License Retention)",
+    "licenseId": "FSFULLR"
+  },
+  {
+    "name": "FSF Unlimited License (with License Retention and Short Disclaimer)",
+    "licenseId": "FSFULLRSD"
+  },
+  {
+    "name": "FSF Unlimited License (With License Retention and Warranty Disclaimer)",
+    "licenseId": "FSFULLRWD"
+  },
+  {
+    "name": "Functional Source License, Version 1.1, ALv2 Future License",
+    "licenseId": "FSL-1.1-ALv2"
+  },
+  {
+    "name": "Functional Source License, Version 1.1, MIT Future License",
+    "licenseId": "FSL-1.1-MIT"
+  },
+  {
+    "name": "Freetype Project License",
+    "licenseId": "FTL"
+  },
+  {
+    "name": "Fair License",
+    "licenseId": "Fair"
+  },
+  {
+    "name": "Ferguson Twofish License",
+    "licenseId": "Ferguson-Twofish"
+  },
+  {
+    "name": "Frameworx Open License 1.0",
+    "licenseId": "Frameworx-1.0"
+  },
+  {
+    "name": "FreeBSD Documentation License",
+    "licenseId": "FreeBSD-DOC"
+  },
+  {
+    "name": "FreeImage Public License v1.0",
+    "licenseId": "FreeImage"
+  },
+  {
+    "name": "Furuseth License",
+    "licenseId": "Furuseth"
+  },
+  {
+    "name": "Gnome GCR Documentation License",
+    "licenseId": "GCR-docs"
+  },
+  {
+    "name": "GD License",
+    "licenseId": "GD"
+  },
+  {
+    "name": "GNU Free Documentation License v1.1",
+    "licenseId": "GFDL-1.1"
+  },
+  {
+    "name": "GNU Free Documentation License v1.1 only - invariants",
+    "licenseId": "GFDL-1.1-invariants-only"
+  },
+  {
+    "name": "GNU Free Documentation License v1.1 or later - invariants",
+    "licenseId": "GFDL-1.1-invariants-or-later"
+  },
+  {
+    "name": "GNU Free Documentation License v1.1 only - no invariants",
+    "licenseId": "GFDL-1.1-no-invariants-only"
+  },
+  {
+    "name": "GNU Free Documentation License v1.1 or later - no invariants",
+    "licenseId": "GFDL-1.1-no-invariants-or-later"
+  },
+  {
+    "name": "GNU Free Documentation License v1.1 only",
+    "licenseId": "GFDL-1.1-only"
+  },
+  {
+    "name": "GNU Free Documentation License v1.1 or later",
+    "licenseId": "GFDL-1.1-or-later"
+  },
+  {
+    "name": "GNU Free Documentation License v1.2",
+    "licenseId": "GFDL-1.2"
+  },
+  {
+    "name": "GNU Free Documentation License v1.2 only - invariants",
+    "licenseId": "GFDL-1.2-invariants-only"
+  },
+  {
+    "name": "GNU Free Documentation License v1.2 or later - invariants",
+    "licenseId": "GFDL-1.2-invariants-or-later"
+  },
+  {
+    "name": "GNU Free Documentation License v1.2 only - no invariants",
+    "licenseId": "GFDL-1.2-no-invariants-only"
+  },
+  {
+    "name": "GNU Free Documentation License v1.2 or later - no invariants",
+    "licenseId": "GFDL-1.2-no-invariants-or-later"
+  },
+  {
+    "name": "GNU Free Documentation License v1.2 only",
+    "licenseId": "GFDL-1.2-only"
+  },
+  {
+    "name": "GNU Free Documentation License v1.2 or later",
+    "licenseId": "GFDL-1.2-or-later"
+  },
+  {
+    "name": "GNU Free Documentation License v1.3",
+    "licenseId": "GFDL-1.3"
+  },
+  {
+    "name": "GNU Free Documentation License v1.3 only - invariants",
+    "licenseId": "GFDL-1.3-invariants-only"
+  },
+  {
+    "name": "GNU Free Documentation License v1.3 or later - invariants",
+    "licenseId": "GFDL-1.3-invariants-or-later"
+  },
+  {
+    "name": "GNU Free Documentation License v1.3 only - no invariants",
+    "licenseId": "GFDL-1.3-no-invariants-only"
+  },
+  {
+    "name": "GNU Free Documentation License v1.3 or later - no invariants",
+    "licenseId": "GFDL-1.3-no-invariants-or-later"
+  },
+  {
+    "name": "GNU Free Documentation License v1.3 only",
+    "licenseId": "GFDL-1.3-only"
+  },
+  {
+    "name": "GNU Free Documentation License v1.3 or later",
+    "licenseId": "GFDL-1.3-or-later"
+  },
+  {
+    "name": "GL2PS License",
+    "licenseId": "GL2PS"
+  },
+  {
+    "name": "Good Luck With That Public License",
+    "licenseId": "GLWTPL"
+  },
+  {
+    "name": "GNU General Public License v1.0 only",
+    "licenseId": "GPL-1.0"
+  },
+  {
+    "name": "GNU General Public License v1.0 or later",
+    "licenseId": "GPL-1.0+"
+  },
+  {
+    "name": "GNU General Public License v1.0 only",
+    "licenseId": "GPL-1.0-only"
+  },
+  {
+    "name": "GNU General Public License v1.0 or later",
+    "licenseId": "GPL-1.0-or-later"
+  },
+  {
+    "name": "GNU General Public License v2.0 only",
+    "licenseId": "GPL-2.0"
+  },
+  {
+    "name": "GNU General Public License v2.0 or later",
+    "licenseId": "GPL-2.0+"
+  },
+  {
+    "name": "GNU General Public License v2.0 only",
+    "licenseId": "GPL-2.0-only"
+  },
+  {
+    "name": "GNU General Public License v2.0 or later",
+    "licenseId": "GPL-2.0-or-later"
+  },
+  {
+    "name": "GNU General Public License v2.0 w/GCC Runtime Library exception",
+    "licenseId": "GPL-2.0-with-GCC-exception"
+  },
+  {
+    "name": "GNU General Public License v2.0 w/Autoconf exception",
+    "licenseId": "GPL-2.0-with-autoconf-exception"
+  },
+  {
+    "name": "GNU General Public License v2.0 w/Bison exception",
+    "licenseId": "GPL-2.0-with-bison-exception"
+  },
+  {
+    "name": "GNU General Public License v2.0 w/Classpath exception",
+    "licenseId": "GPL-2.0-with-classpath-exception"
+  },
+  {
+    "name": "GNU General Public License v2.0 w/Font exception",
+    "licenseId": "GPL-2.0-with-font-exception"
+  },
+  {
+    "name": "GNU General Public License v3.0 only",
+    "licenseId": "GPL-3.0"
+  },
+  {
+    "name": "GNU General Public License v3.0 or later",
+    "licenseId": "GPL-3.0+"
+  },
+  {
+    "name": "GNU General Public License v3.0 only",
+    "licenseId": "GPL-3.0-only"
+  },
+  {
+    "name": "GNU General Public License v3.0 or later",
+    "licenseId": "GPL-3.0-or-later"
+  },
+  {
+    "name": "GNU General Public License v3.0 w/GCC Runtime Library exception",
+    "licenseId": "GPL-3.0-with-GCC-exception"
+  },
+  {
+    "name": "GNU General Public License v3.0 w/Autoconf exception",
+    "licenseId": "GPL-3.0-with-autoconf-exception"
+  },
+  {
+    "name": "Game Programming Gems License",
+    "licenseId": "Game-Programming-Gems"
+  },
+  {
+    "name": "Giftware License",
+    "licenseId": "Giftware"
+  },
+  {
+    "name": "3dfx Glide License",
+    "licenseId": "Glide"
+  },
+  {
+    "name": "Glulxe License",
+    "licenseId": "Glulxe"
+  },
+  {
+    "name": "Graphics Gems License",
+    "licenseId": "Graphics-Gems"
+  },
+  {
+    "name": "Gutmann License",
+    "licenseId": "Gutmann"
+  },
+  {
+    "name": "HDF5 License",
+    "licenseId": "HDF5"
+  },
+  {
+    "name": "HIDAPI License",
+    "licenseId": "HIDAPI"
+  },
+  {
+    "name": "Hewlett-Packard 1986 License",
+    "licenseId": "HP-1986"
+  },
+  {
+    "name": "Hewlett-Packard 1989 License",
+    "licenseId": "HP-1989"
+  },
+  {
+    "name": "Historical Permission Notice and Disclaimer",
+    "licenseId": "HPND"
+  },
+  {
+    "name": "Historical Permission Notice and Disclaimer - DEC variant",
+    "licenseId": "HPND-DEC"
+  },
+  {
+    "name": "Historical Permission Notice and Disclaimer - Fenneberg-Livingston variant",
+    "licenseId": "HPND-Fenneberg-Livingston"
+  },
+  {
+    "name": "Historical Permission Notice and Disclaimer    - INRIA-IMAG variant",
+    "licenseId": "HPND-INRIA-IMAG"
+  },
+  {
+    "name": "Historical Permission Notice and Disclaimer - Intel variant",
+    "licenseId": "HPND-Intel"
+  },
+  {
+    "name": "Historical Permission Notice and Disclaimer - Kevlin Henney variant",
+    "licenseId": "HPND-Kevlin-Henney"
+  },
+  {
+    "name": "Historical Permission Notice and Disclaimer with MIT disclaimer",
+    "licenseId": "HPND-MIT-disclaimer"
+  },
+  {
+    "name": "Historical Permission Notice and Disclaimer - Markus Kuhn variant",
+    "licenseId": "HPND-Markus-Kuhn"
+  },
+  {
+    "name": "Historical Permission Notice and Disclaimer - Netrek variant",
+    "licenseId": "HPND-Netrek"
+  },
+  {
+    "name": "Historical Permission Notice and Disclaimer - Pbmplus variant",
+    "licenseId": "HPND-Pbmplus"
+  },
+  {
+    "name": "Historical Permission Notice and Disclaimer - SMC variant",
+    "licenseId": "HPND-SMC"
+  },
+  {
+    "name": "Historical Permission Notice and Disclaimer - University of California variant",
+    "licenseId": "HPND-UC"
+  },
+  {
+    "name": "Historical Permission Notice and Disclaimer - University of California, US export warning",
+    "licenseId": "HPND-UC-export-US"
+  },
+  {
+    "name": "Historical Permission Notice and Disclaimer - documentation variant",
+    "licenseId": "HPND-doc"
+  },
+  {
+    "name": "Historical Permission Notice and Disclaimer - documentation sell variant",
+    "licenseId": "HPND-doc-sell"
+  },
+  {
+    "name": "HPND with US Government export control warning",
+    "licenseId": "HPND-export-US"
+  },
+  {
+    "name": "HPND with US Government export control warning and acknowledgment",
+    "licenseId": "HPND-export-US-acknowledgement"
+  },
+  {
+    "name": "HPND with US Government export control warning and modification rqmt",
+    "licenseId": "HPND-export-US-modify"
+  },
+  {
+    "name": "HPND with US Government export control and 2 disclaimers",
+    "licenseId": "HPND-export2-US"
+  },
+  {
+    "name": "Historical Permission Notice and Disclaimer - merchantability variant",
+    "licenseId": "HPND-merchantability-variant"
+  },
+  {
+    "name": "Historical Permission Notice and Disclaimer - sell xserver variant with MIT disclaimer",
+    "licenseId": "HPND-sell-MIT-disclaimer-xserver"
+  },
+  {
+    "name": "Historical Permission Notice and Disclaimer - sell regexpr variant",
+    "licenseId": "HPND-sell-regexpr"
+  },
+  {
+    "name": "Historical Permission Notice and Disclaimer - sell variant",
+    "licenseId": "HPND-sell-variant"
+  },
+  {
+    "name": "HPND sell variant with MIT disclaimer",
+    "licenseId": "HPND-sell-variant-MIT-disclaimer"
+  },
+  {
+    "name": "HPND sell variant with MIT disclaimer - reverse",
+    "licenseId": "HPND-sell-variant-MIT-disclaimer-rev"
+  },
+  {
+    "name": "HPND - sell variant with safety critical systems clause",
+    "licenseId": "HPND-sell-variant-critical-systems"
+  },
+  {
+    "name": "HTML Tidy License",
+    "licenseId": "HTMLTIDY"
+  },
+  {
+    "name": "Haskell Language Report License",
+    "licenseId": "HaskellReport"
+  },
+  {
+    "name": "Hippocratic License 2.1",
+    "licenseId": "Hippocratic-2.1"
+  },
+  {
+    "name": "IBM PowerPC Initialization and Boot Software",
+    "licenseId": "IBM-pibs"
+  },
+  {
+    "name": "ICU License",
+    "licenseId": "ICU"
+  },
+  {
+    "name": "IEC    Code Components End-user licence agreement",
+    "licenseId": "IEC-Code-Components-EULA"
+  },
+  {
+    "name": "Independent JPEG Group License",
+    "licenseId": "IJG"
+  },
+  {
+    "name": "Independent JPEG Group License - short",
+    "licenseId": "IJG-short"
+  },
+  {
+    "name": "IPA Font License",
+    "licenseId": "IPA"
+  },
+  {
+    "name": "IBM Public License v1.0",
+    "licenseId": "IPL-1.0"
+  },
+  {
+    "name": "ISC License",
+    "licenseId": "ISC"
+  },
+  {
+    "name": "ISC Veillard variant",
+    "licenseId": "ISC-Veillard"
+  },
+  {
+    "name": "ISO permission notice",
+    "licenseId": "ISO-permission"
+  },
+  {
+    "name": "ImageMagick License",
+    "licenseId": "ImageMagick"
+  },
+  {
+    "name": "Imlib2 License",
+    "licenseId": "Imlib2"
+  },
+  {
+    "name": "Info-ZIP License",
+    "licenseId": "Info-ZIP"
+  },
+  {
+    "name": "Inner Net License v2.0",
+    "licenseId": "Inner-Net-2.0"
+  },
+  {
+    "name": "Inno Setup License",
+    "licenseId": "InnoSetup"
+  },
+  {
+    "name": "Intel Open Source License",
+    "licenseId": "Intel"
+  },
+  {
+    "name": "Intel ACPI Software License Agreement",
+    "licenseId": "Intel-ACPI"
+  },
+  {
+    "name": "Interbase Public License v1.0",
+    "licenseId": "Interbase-1.0"
+  },
+  {
+    "name": "JPL Image Use Policy",
+    "licenseId": "JPL-image"
+  },
+  {
+    "name": "Japan Network Information Center License",
+    "licenseId": "JPNIC"
+  },
+  {
+    "name": "JSON License",
+    "licenseId": "JSON"
+  },
+  {
+    "name": "Jam License",
+    "licenseId": "Jam"
+  },
+  {
+    "name": "JasPer License",
+    "licenseId": "JasPer-2.0"
+  },
+  {
+    "name": "Kastrup License",
+    "licenseId": "Kastrup"
+  },
+  {
+    "name": "Kazlib License",
+    "licenseId": "Kazlib"
+  },
+  {
+    "name": "Knuth CTAN License",
+    "licenseId": "Knuth-CTAN"
+  },
+  {
+    "name": "Licence Art Libre 1.2",
+    "licenseId": "LAL-1.2"
+  },
+  {
+    "name": "Licence Art Libre 1.3",
+    "licenseId": "LAL-1.3"
+  },
+  {
+    "name": "GNU Library General Public License v2 only",
+    "licenseId": "LGPL-2.0"
+  },
+  {
+    "name": "GNU Library General Public License v2 or later",
+    "licenseId": "LGPL-2.0+"
+  },
+  {
+    "name": "GNU Library General Public License v2 only",
+    "licenseId": "LGPL-2.0-only"
+  },
+  {
+    "name": "GNU Library General Public License v2 or later",
+    "licenseId": "LGPL-2.0-or-later"
+  },
+  {
+    "name": "GNU Lesser General Public License v2.1 only",
+    "licenseId": "LGPL-2.1"
+  },
+  {
+    "name": "GNU Lesser General Public License v2.1 or later",
+    "licenseId": "LGPL-2.1+"
+  },
+  {
+    "name": "GNU Lesser General Public License v2.1 only",
+    "licenseId": "LGPL-2.1-only"
+  },
+  {
+    "name": "GNU Lesser General Public License v2.1 or later",
+    "licenseId": "LGPL-2.1-or-later"
+  },
+  {
+    "name": "GNU Lesser General Public License v3.0 only",
+    "licenseId": "LGPL-3.0"
+  },
+  {
+    "name": "GNU Lesser General Public License v3.0 or later",
+    "licenseId": "LGPL-3.0+"
+  },
+  {
+    "name": "GNU Lesser General Public License v3.0 only",
+    "licenseId": "LGPL-3.0-only"
+  },
+  {
+    "name": "GNU Lesser General Public License v3.0 or later",
+    "licenseId": "LGPL-3.0-or-later"
+  },
+  {
+    "name": "Lesser General Public License For Linguistic Resources",
+    "licenseId": "LGPLLR"
+  },
+  {
+    "name": "Common Lisp LOOP License",
+    "licenseId": "LOOP"
+  },
+  {
+    "name": "LPD Documentation License",
+    "licenseId": "LPD-document"
+  },
+  {
+    "name": "Lucent Public License Version 1.0",
+    "licenseId": "LPL-1.0"
+  },
+  {
+    "name": "Lucent Public License v1.02",
+    "licenseId": "LPL-1.02"
+  },
+  {
+    "name": "LaTeX Project Public License v1.0",
+    "licenseId": "LPPL-1.0"
+  },
+  {
+    "name": "LaTeX Project Public License v1.1",
+    "licenseId": "LPPL-1.1"
+  },
+  {
+    "name": "LaTeX Project Public License v1.2",
+    "licenseId": "LPPL-1.2"
+  },
+  {
+    "name": "LaTeX Project Public License v1.3a",
+    "licenseId": "LPPL-1.3a"
+  },
+  {
+    "name": "LaTeX Project Public License v1.3c",
+    "licenseId": "LPPL-1.3c"
+  },
+  {
+    "name": "LZMA SDK License (versions 9.11 to 9.20)",
+    "licenseId": "LZMA-SDK-9.11-to-9.20"
+  },
+  {
+    "name": "LZMA SDK License (versions 9.22 and beyond)",
+    "licenseId": "LZMA-SDK-9.22"
+  },
+  {
+    "name": "Latex2e License",
+    "licenseId": "Latex2e"
+  },
+  {
+    "name": "Latex2e with translated notice permission",
+    "licenseId": "Latex2e-translated-notice"
+  },
+  {
+    "name": "Leptonica License",
+    "licenseId": "Leptonica"
+  },
+  {
+    "name": "Licence Libre du Québec – Permissive version 1.1",
+    "licenseId": "LiLiQ-P-1.1"
+  },
+  {
+    "name": "Licence Libre du Québec – Réciprocité version 1.1",
+    "licenseId": "LiLiQ-R-1.1"
+  },
+  {
+    "name": "Licence Libre du Québec – Réciprocité forte version 1.1",
+    "licenseId": "LiLiQ-Rplus-1.1"
+  },
+  {
+    "name": "libpng License",
+    "licenseId": "Libpng"
+  },
+  {
+    "name": "Linux Kernel Variant of OpenIB.org license",
+    "licenseId": "Linux-OpenIB"
+  },
+  {
+    "name": "Linux man-pages - 1 paragraph",
+    "licenseId": "Linux-man-pages-1-para"
+  },
+  {
+    "name": "Linux man-pages Copyleft",
+    "licenseId": "Linux-man-pages-copyleft"
+  },
+  {
+    "name": "Linux man-pages Copyleft - 2 paragraphs",
+    "licenseId": "Linux-man-pages-copyleft-2-para"
+  },
+  {
+    "name": "Linux man-pages Copyleft Variant",
+    "licenseId": "Linux-man-pages-copyleft-var"
+  },
+  {
+    "name": "Lucida Bitmap Fonts License",
+    "licenseId": "Lucida-Bitmap-Fonts"
+  },
+  {
+    "name": "MIPS License",
+    "licenseId": "MIPS"
+  },
+  {
+    "name": "MIT License",
+    "licenseId": "MIT"
+  },
+  {
+    "name": "MIT No Attribution",
+    "licenseId": "MIT-0"
+  },
+  {
+    "name": "CMU License",
+    "licenseId": "MIT-CMU"
+  },
+  {
+    "name": "MIT Click License",
+    "licenseId": "MIT-Click"
+  },
+  {
+    "name": "MIT Festival Variant",
+    "licenseId": "MIT-Festival"
+  },
+  {
+    "name": "MIT Khronos - old variant",
+    "licenseId": "MIT-Khronos-old"
+  },
+  {
+    "name": "MIT License Modern Variant",
+    "licenseId": "MIT-Modern-Variant"
+  },
+  {
+    "name": "MIT-STK License",
+    "licenseId": "MIT-STK"
+  },
+  {
+    "name": "MIT Tom Wu Variant",
+    "licenseId": "MIT-Wu"
+  },
+  {
+    "name": "Enlightenment License (e16)",
+    "licenseId": "MIT-advertising"
+  },
+  {
+    "name": "enna License",
+    "licenseId": "MIT-enna"
+  },
+  {
+    "name": "feh License",
+    "licenseId": "MIT-feh"
+  },
+  {
+    "name": "MIT Open Group variant",
+    "licenseId": "MIT-open-group"
+  },
+  {
+    "name": "MIT testregex Variant",
+    "licenseId": "MIT-testregex"
+  },
+  {
+    "name": "MIT +no-false-attribs license",
+    "licenseId": "MITNFA"
+  },
+  {
+    "name": "MMIXware License",
+    "licenseId": "MMIXware"
+  },
+  {
+    "name": "Minecraft Mod Public License v1.0.1",
+    "licenseId": "MMPL-1.0.1"
+  },
+  {
+    "name": "MPEG Software Simulation",
+    "licenseId": "MPEG-SSG"
+  },
+  {
+    "name": "Mozilla Public License 1.0",
+    "licenseId": "MPL-1.0"
+  },
+  {
+    "name": "Mozilla Public License 1.1",
+    "licenseId": "MPL-1.1"
+  },
+  {
+    "name": "Mozilla Public License 2.0",
+    "licenseId": "MPL-2.0"
+  },
+  {
+    "name": "Mozilla Public License 2.0 (no copyleft exception)",
+    "licenseId": "MPL-2.0-no-copyleft-exception"
+  },
+  {
+    "name": "Microsoft Limited Public License",
+    "licenseId": "MS-LPL"
+  },
+  {
+    "name": "Microsoft Public License",
+    "licenseId": "MS-PL"
+  },
+  {
+    "name": "Microsoft Reciprocal License",
+    "licenseId": "MS-RL"
+  },
+  {
+    "name": "Matrix Template Library License",
+    "licenseId": "MTLL"
+  },
+  {
+    "name": "Mackerras 3-Clause License",
+    "licenseId": "Mackerras-3-Clause"
+  },
+  {
+    "name": "Mackerras 3-Clause - acknowledgment variant",
+    "licenseId": "Mackerras-3-Clause-acknowledgment"
+  },
+  {
+    "name": "MakeIndex License",
+    "licenseId": "MakeIndex"
+  },
+  {
+    "name": "Martin Birgmeier License",
+    "licenseId": "Martin-Birgmeier"
+  },
+  {
+    "name": "McPhee Slideshow License",
+    "licenseId": "McPhee-slideshow"
+  },
+  {
+    "name": "Minpack License",
+    "licenseId": "Minpack"
+  },
+  {
+    "name": "The MirOS Licence",
+    "licenseId": "MirOS"
+  },
+  {
+    "name": "Motosoto License",
+    "licenseId": "Motosoto"
+  },
+  {
+    "name": "Mulan Permissive Software License, Version 1",
+    "licenseId": "MulanPSL-1.0"
+  },
+  {
+    "name": "Mulan Permissive Software License, Version 2",
+    "licenseId": "MulanPSL-2.0"
+  },
+  {
+    "name": "Multics License",
+    "licenseId": "Multics"
+  },
+  {
+    "name": "Mup License",
+    "licenseId": "Mup"
+  },
+  {
+    "name": "Nara Institute of Science and Technology License (2003)",
+    "licenseId": "NAIST-2003"
+  },
+  {
+    "name": "NASA Open Source Agreement 1.3",
+    "licenseId": "NASA-1.3"
+  },
+  {
+    "name": "Net Boolean Public License v1",
+    "licenseId": "NBPL-1.0"
+  },
+  {
+    "name": "NCBI Public Domain Notice",
+    "licenseId": "NCBI-PD"
+  },
+  {
+    "name": "Non-Commercial Government Licence",
+    "licenseId": "NCGL-UK-2.0"
+  },
+  {
+    "name": "NCL Source Code License",
+    "licenseId": "NCL"
+  },
+  {
+    "name": "University of Illinois/NCSA Open Source License",
+    "licenseId": "NCSA"
+  },
+  {
+    "name": "Nethack General Public License",
+    "licenseId": "NGPL"
+  },
+  {
+    "name": "NICTA Public Software License, Version 1.0",
+    "licenseId": "NICTA-1.0"
+  },
+  {
+    "name": "NIST Public Domain Notice",
+    "licenseId": "NIST-PD"
+  },
+  {
+    "name": "NIST    Public Domain Notice TNT variant",
+    "licenseId": "NIST-PD-TNT"
+  },
+  {
+    "name": "NIST Public Domain Notice with license fallback",
+    "licenseId": "NIST-PD-fallback"
+  },
+  {
+    "name": "NIST Software License",
+    "licenseId": "NIST-Software"
+  },
+  {
+    "name": "Norwegian Licence for Open Government Data (NLOD) 1.0",
+    "licenseId": "NLOD-1.0"
+  },
+  {
+    "name": "Norwegian Licence for Open Government Data (NLOD) 2.0",
+    "licenseId": "NLOD-2.0"
+  },
+  {
+    "name": "No Limit Public License",
+    "licenseId": "NLPL"
+  },
+  {
+    "name": "Netizen Open Source License",
+    "licenseId": "NOSL"
+  },
+  {
+    "name": "Netscape Public License v1.0",
+    "licenseId": "NPL-1.0"
+  },
+  {
+    "name": "Netscape Public License v1.1",
+    "licenseId": "NPL-1.1"
+  },
+  {
+    "name": "Non-Profit Open Software License 3.0",
+    "licenseId": "NPOSL-3.0"
+  },
+  {
+    "name": "NRL License",
+    "licenseId": "NRL"
+  },
+  {
+    "name": "NTIA Public Domain Notice",
+    "licenseId": "NTIA-PD"
+  },
+  {
+    "name": "NTP License",
+    "licenseId": "NTP"
+  },
+  {
+    "name": "NTP No Attribution",
+    "licenseId": "NTP-0"
+  },
+  {
+    "name": "Naumen Public License",
+    "licenseId": "Naumen"
+  },
+  {
+    "name": "Net-SNMP License",
+    "licenseId": "Net-SNMP"
+  },
+  {
+    "name": "NetCDF license",
+    "licenseId": "NetCDF"
+  },
+  {
+    "name": "Newsletr License",
+    "licenseId": "Newsletr"
+  },
+  {
+    "name": "Nokia Open Source License",
+    "licenseId": "Nokia"
+  },
+  {
+    "name": "Noweb License",
+    "licenseId": "Noweb"
+  },
+  {
+    "name": "Nunit License",
+    "licenseId": "Nunit"
+  },
+  {
+    "name": "Open Use of Data Agreement v1.0",
+    "licenseId": "O-UDA-1.0"
+  },
+  {
+    "name": "OAR License",
+    "licenseId": "OAR"
+  },
+  {
+    "name": "Open CASCADE Technology Public License",
+    "licenseId": "OCCT-PL"
+  },
+  {
+    "name": "OCLC Research Public License 2.0",
+    "licenseId": "OCLC-2.0"
+  },
+  {
+    "name": "Open Data Commons Attribution License v1.0",
+    "licenseId": "ODC-By-1.0"
+  },
+  {
+    "name": "Open Data Commons Open Database License v1.0",
+    "licenseId": "ODbL-1.0"
+  },
+  {
+    "name": "OFFIS License",
+    "licenseId": "OFFIS"
+  },
+  {
+    "name": "SIL Open Font License 1.0",
+    "licenseId": "OFL-1.0"
+  },
+  {
+    "name": "SIL Open Font License 1.0 with Reserved Font Name",
+    "licenseId": "OFL-1.0-RFN"
+  },
+  {
+    "name": "SIL Open Font License 1.0 with no Reserved Font Name",
+    "licenseId": "OFL-1.0-no-RFN"
+  },
+  {
+    "name": "SIL Open Font License 1.1",
+    "licenseId": "OFL-1.1"
+  },
+  {
+    "name": "SIL Open Font License 1.1 with Reserved Font Name",
+    "licenseId": "OFL-1.1-RFN"
+  },
+  {
+    "name": "SIL Open Font License 1.1 with no Reserved Font Name",
+    "licenseId": "OFL-1.1-no-RFN"
+  },
+  {
+    "name": "OGC Software License, Version 1.0",
+    "licenseId": "OGC-1.0"
+  },
+  {
+    "name": "Taiwan Open Government Data License, version 1.0",
+    "licenseId": "OGDL-Taiwan-1.0"
+  },
+  {
+    "name": "Open Government Licence - Canada",
+    "licenseId": "OGL-Canada-2.0"
+  },
+  {
+    "name": "Open Government Licence v1.0",
+    "licenseId": "OGL-UK-1.0"
+  },
+  {
+    "name": "Open Government Licence v2.0",
+    "licenseId": "OGL-UK-2.0"
+  },
+  {
+    "name": "Open Government Licence v3.0",
+    "licenseId": "OGL-UK-3.0"
+  },
+  {
+    "name": "Open Group Test Suite License",
+    "licenseId": "OGTSL"
+  },
+  {
+    "name": "Open LDAP Public License v1.1",
+    "licenseId": "OLDAP-1.1"
+  },
+  {
+    "name": "Open LDAP Public License v1.2",
+    "licenseId": "OLDAP-1.2"
+  },
+  {
+    "name": "Open LDAP Public License v1.3",
+    "licenseId": "OLDAP-1.3"
+  },
+  {
+    "name": "Open LDAP Public License v1.4",
+    "licenseId": "OLDAP-1.4"
+  },
+  {
+    "name": "Open LDAP Public License v2.0 (or possibly 2.0A and 2.0B)",
+    "licenseId": "OLDAP-2.0"
+  },
+  {
+    "name": "Open LDAP Public License v2.0.1",
+    "licenseId": "OLDAP-2.0.1"
+  },
+  {
+    "name": "Open LDAP Public License v2.1",
+    "licenseId": "OLDAP-2.1"
+  },
+  {
+    "name": "Open LDAP Public License v2.2",
+    "licenseId": "OLDAP-2.2"
+  },
+  {
+    "name": "Open LDAP Public License v2.2.1",
+    "licenseId": "OLDAP-2.2.1"
+  },
+  {
+    "name": "Open LDAP Public License 2.2.2",
+    "licenseId": "OLDAP-2.2.2"
+  },
+  {
+    "name": "Open LDAP Public License v2.3",
+    "licenseId": "OLDAP-2.3"
+  },
+  {
+    "name": "Open LDAP Public License v2.4",
+    "licenseId": "OLDAP-2.4"
+  },
+  {
+    "name": "Open LDAP Public License v2.5",
+    "licenseId": "OLDAP-2.5"
+  },
+  {
+    "name": "Open LDAP Public License v2.6",
+    "licenseId": "OLDAP-2.6"
+  },
+  {
+    "name": "Open LDAP Public License v2.7",
+    "licenseId": "OLDAP-2.7"
+  },
+  {
+    "name": "Open LDAP Public License v2.8",
+    "licenseId": "OLDAP-2.8"
+  },
+  {
+    "name": "Open Logistics Foundation License Version 1.3",
+    "licenseId": "OLFL-1.3"
+  },
+  {
+    "name": "Open Market License",
+    "licenseId": "OML"
+  },
+  {
+    "name": "Open Public License v1.0",
+    "licenseId": "OPL-1.0"
+  },
+  {
+    "name": "United    Kingdom Open Parliament Licence v3.0",
+    "licenseId": "OPL-UK-3.0"
+  },
+  {
+    "name": "Open Publication License v1.0",
+    "licenseId": "OPUBL-1.0"
+  },
+  {
+    "name": "OSC License 1.0",
+    "licenseId": "OSC-1.0"
+  },
+  {
+    "name": "OSET Public License version 2.1",
+    "licenseId": "OSET-PL-2.1"
+  },
+  {
+    "name": "Open Software License 1.0",
+    "licenseId": "OSL-1.0"
+  },
+  {
+    "name": "Open Software License 1.1",
+    "licenseId": "OSL-1.1"
+  },
+  {
+    "name": "Open Software License 2.0",
+    "licenseId": "OSL-2.0"
+  },
+  {
+    "name": "Open Software License 2.1",
+    "licenseId": "OSL-2.1"
+  },
+  {
+    "name": "Open Software License 3.0",
+    "licenseId": "OSL-3.0"
+  },
+  {
+    "name": "OSSP License",
+    "licenseId": "OSSP"
+  },
+  {
+    "name": "OpenMDW License Agreement v1.0",
+    "licenseId": "OpenMDW-1.0"
+  },
+  {
+    "name": "OpenPBS v2.3 Software License",
+    "licenseId": "OpenPBS-2.3"
+  },
+  {
+    "name": "OpenSSL License",
+    "licenseId": "OpenSSL"
+  },
+  {
+    "name": "OpenSSL License - standalone",
+    "licenseId": "OpenSSL-standalone"
+  },
+  {
+    "name": "OpenVision License",
+    "licenseId": "OpenVision"
+  },
+  {
+    "name": "PADL License",
+    "licenseId": "PADL"
+  },
+  {
+    "name": "Open Data Commons Public Domain Dedication & License 1.0",
+    "licenseId": "PDDL-1.0"
+  },
+  {
+    "name": "PHP License v3.0",
+    "licenseId": "PHP-3.0"
+  },
+  {
+    "name": "PHP License v3.01",
+    "licenseId": "PHP-3.01"
+  },
+  {
+    "name": "Peer Production License",
+    "licenseId": "PPL"
+  },
+  {
+    "name": "Python Software Foundation License 2.0",
+    "licenseId": "PSF-2.0"
+  },
+  {
+    "name": "ParaType Free Font Licensing Agreement v1.3",
+    "licenseId": "ParaType-Free-Font-1.3"
+  },
+  {
+    "name": "The Parity Public License 6.0.0",
+    "licenseId": "Parity-6.0.0"
+  },
+  {
+    "name": "The Parity Public License 7.0.0",
+    "licenseId": "Parity-7.0.0"
+  },
+  {
+    "name": "Pixar License",
+    "licenseId": "Pixar"
+  },
+  {
+    "name": "Plexus Classworlds License",
+    "licenseId": "Plexus"
+  },
+  {
+    "name": "PolyForm Noncommercial License 1.0.0",
+    "licenseId": "PolyForm-Noncommercial-1.0.0"
+  },
+  {
+    "name": "PolyForm Small Business License 1.0.0",
+    "licenseId": "PolyForm-Small-Business-1.0.0"
+  },
+  {
+    "name": "PostgreSQL License",
+    "licenseId": "PostgreSQL"
+  },
+  {
+    "name": "Python License 2.0",
+    "licenseId": "Python-2.0"
+  },
+  {
+    "name": "Python License 2.0.1",
+    "licenseId": "Python-2.0.1"
+  },
+  {
+    "name": "Q Public License 1.0",
+    "licenseId": "QPL-1.0"
+  },
+  {
+    "name": "Q Public License 1.0 - INRIA 2004 variant",
+    "licenseId": "QPL-1.0-INRIA-2004"
+  },
+  {
+    "name": "Qhull License",
+    "licenseId": "Qhull"
+  },
+  {
+    "name": "Red Hat eCos Public License v1.1",
+    "licenseId": "RHeCos-1.1"
+  },
+  {
+    "name": "Reciprocal Public License 1.1",
+    "licenseId": "RPL-1.1"
+  },
+  {
+    "name": "Reciprocal Public License 1.5",
+    "licenseId": "RPL-1.5"
+  },
+  {
+    "name": "RealNetworks Public Source License v1.0",
+    "licenseId": "RPSL-1.0"
+  },
+  {
+    "name": "RSA Message-Digest License",
+    "licenseId": "RSA-MD"
+  },
+  {
+    "name": "Ricoh Source Code Public License",
+    "licenseId": "RSCPL"
+  },
+  {
+    "name": "Rdisc License",
+    "licenseId": "Rdisc"
+  },
+  {
+    "name": "Ruby License",
+    "licenseId": "Ruby"
+  },
+  {
+    "name": "Ruby pty extension license",
+    "licenseId": "Ruby-pty"
+  },
+  {
+    "name": "Sax Public Domain Notice",
+    "licenseId": "SAX-PD"
+  },
+  {
+    "name": "Sax Public Domain Notice 2.0",
+    "licenseId": "SAX-PD-2.0"
+  },
+  {
+    "name": "SCEA Shared Source License",
+    "licenseId": "SCEA"
+  },
+  {
+    "name": "SGI Free Software License B v1.0",
+    "licenseId": "SGI-B-1.0"
+  },
+  {
+    "name": "SGI Free Software License B v1.1",
+    "licenseId": "SGI-B-1.1"
+  },
+  {
+    "name": "SGI Free Software License B v2.0",
+    "licenseId": "SGI-B-2.0"
+  },
+  {
+    "name": "SGI OpenGL License",
+    "licenseId": "SGI-OpenGL"
+  },
+  {
+    "name": "SGMLUG Parser Materials License",
+    "licenseId": "SGMLUG-PM"
+  },
+  {
+    "name": "SGP4 Permission Notice",
+    "licenseId": "SGP4"
+  },
+  {
+    "name": "Solderpad Hardware License v0.5",
+    "licenseId": "SHL-0.5"
+  },
+  {
+    "name": "Solderpad Hardware License, Version 0.51",
+    "licenseId": "SHL-0.51"
+  },
+  {
+    "name": "Sun Industry Standards Source License v1.1",
+    "licenseId": "SISSL"
+  },
+  {
+    "name": "Sun Industry Standards Source License v1.2",
+    "licenseId": "SISSL-1.2"
+  },
+  {
+    "name": "SL License",
+    "licenseId": "SL"
+  },
+  {
+    "name": "SMAIL General Public License",
+    "licenseId": "SMAIL-GPL"
+  },
+  {
+    "name": "Standard ML of New Jersey License",
+    "licenseId": "SMLNJ"
+  },
+  {
+    "name": "Secure Messaging Protocol Public License",
+    "licenseId": "SMPPL"
+  },
+  {
+    "name": "SNIA Public License 1.1",
+    "licenseId": "SNIA"
+  },
+  {
+    "name": "SOFA Software License",
+    "licenseId": "SOFA"
+  },
+  {
+    "name": "Sun Public License v1.0",
+    "licenseId": "SPL-1.0"
+  },
+  {
+    "name": "SSH OpenSSH license",
+    "licenseId": "SSH-OpenSSH"
+  },
+  {
+    "name": "SSH short notice",
+    "licenseId": "SSH-short"
+  },
+  {
+    "name": "SSLeay License - standalone",
+    "licenseId": "SSLeay-standalone"
+  },
+  {
+    "name": "Server Side Public License, v 1",
+    "licenseId": "SSPL-1.0"
+  },
+  {
+    "name": "Sustainable Use License v1.0",
+    "licenseId": "SUL-1.0"
+  },
+  {
+    "name": "Scheme Widget Library (SWL) Software License Agreement",
+    "licenseId": "SWL"
+  },
+  {
+    "name": "Saxpath License",
+    "licenseId": "Saxpath"
+  },
+  {
+    "name": "Scheme Language Report License",
+    "licenseId": "SchemeReport"
+  },
+  {
+    "name": "Sendmail License",
+    "licenseId": "Sendmail"
+  },
+  {
+    "name": "Sendmail License 8.23",
+    "licenseId": "Sendmail-8.23"
+  },
+  {
+    "name": "Sendmail Open Source License v1.1",
+    "licenseId": "Sendmail-Open-Source-1.1"
+  },
+  {
+    "name": "Simple Public License 2.0",
+    "licenseId": "SimPL-2.0"
+  },
+  {
+    "name": "Sleepycat License",
+    "licenseId": "Sleepycat"
+  },
+  {
+    "name": "Soundex License",
+    "licenseId": "Soundex"
+  },
+  {
+    "name": "Spencer License 86",
+    "licenseId": "Spencer-86"
+  },
+  {
+    "name": "Spencer License 94",
+    "licenseId": "Spencer-94"
+  },
+  {
+    "name": "Spencer License 99",
+    "licenseId": "Spencer-99"
+  },
+  {
+    "name": "Standard ML of New Jersey License",
+    "licenseId": "StandardML-NJ"
+  },
+  {
+    "name": "SugarCRM Public License v1.1.3",
+    "licenseId": "SugarCRM-1.1.3"
+  },
+  {
+    "name": "Sun PPP License",
+    "licenseId": "Sun-PPP"
+  },
+  {
+    "name": "Sun PPP License (2000)",
+    "licenseId": "Sun-PPP-2000"
+  },
+  {
+    "name": "SunPro License",
+    "licenseId": "SunPro"
+  },
+  {
+    "name": "Symlinks License",
+    "licenseId": "Symlinks"
+  },
+  {
+    "name": "TAPR Open Hardware License v1.0",
+    "licenseId": "TAPR-OHL-1.0"
+  },
+  {
+    "name": "TCL/TK License",
+    "licenseId": "TCL"
+  },
+  {
+    "name": "TCP Wrappers License",
+    "licenseId": "TCP-wrappers"
+  },
+  {
+    "name": "Transitive Grace Period Public Licence 1.0",
+    "licenseId": "TGPPL-1.0"
+  },
+  {
+    "name": "TMate Open Source License",
+    "licenseId": "TMate"
+  },
+  {
+    "name": "TORQUE v2.5+ Software License v1.1",
+    "licenseId": "TORQUE-1.1"
+  },
+  {
+    "name": "Trusster Open Source License",
+    "licenseId": "TOSL"
+  },
+  {
+    "name": "Time::ParseDate License",
+    "licenseId": "TPDL"
+  },
+  {
+    "name": "THOR Public License 1.0",
+    "licenseId": "TPL-1.0"
+  },
+  {
+    "name": "Text-Tabs+Wrap License",
+    "licenseId": "TTWL"
+  },
+  {
+    "name": "TTYP0 License",
+    "licenseId": "TTYP0"
+  },
+  {
+    "name": "Technische Universitaet Berlin License 1.0",
+    "licenseId": "TU-Berlin-1.0"
+  },
+  {
+    "name": "Technische Universitaet Berlin License 2.0",
+    "licenseId": "TU-Berlin-2.0"
+  },
+  {
+    "name": "TekHVC License",
+    "licenseId": "TekHVC"
+  },
+  {
+    "name": "TermReadKey License",
+    "licenseId": "TermReadKey"
+  },
+  {
+    "name": "ThirdEye License",
+    "licenseId": "ThirdEye"
+  },
+  {
+    "name": "TrustedQSL License",
+    "licenseId": "TrustedQSL"
+  },
+  {
+    "name": "UCAR License",
+    "licenseId": "UCAR"
+  },
+  {
+    "name": "Upstream Compatibility License v1.0",
+    "licenseId": "UCL-1.0"
+  },
+  {
+    "name": "Michigan/Merit Networks License",
+    "licenseId": "UMich-Merit"
+  },
+  {
+    "name": "Universal Permissive License v1.0",
+    "licenseId": "UPL-1.0"
+  },
+  {
+    "name": "Utah Raster Toolkit Run Length Encoded License",
+    "licenseId": "URT-RLE"
+  },
+  {
+    "name": "Ubuntu Font Licence v1.0",
+    "licenseId": "Ubuntu-font-1.0"
+  },
+  {
+    "name": "UnRAR License",
+    "licenseId": "UnRAR"
+  },
+  {
+    "name": "Unicode License v3",
+    "licenseId": "Unicode-3.0"
+  },
+  {
+    "name": "Unicode License Agreement - Data Files and Software (2015)",
+    "licenseId": "Unicode-DFS-2015"
+  },
+  {
+    "name": "Unicode License Agreement - Data Files and Software (2016)",
+    "licenseId": "Unicode-DFS-2016"
+  },
+  {
+    "name": "Unicode Terms of Use",
+    "licenseId": "Unicode-TOU"
+  },
+  {
+    "name": "UnixCrypt License",
+    "licenseId": "UnixCrypt"
+  },
+  {
+    "name": "The Unlicense",
+    "licenseId": "Unlicense"
+  },
+  {
+    "name": "Unlicense - libtelnet variant",
+    "licenseId": "Unlicense-libtelnet"
+  },
+  {
+    "name": "Unlicense - libwhirlpool variant",
+    "licenseId": "Unlicense-libwhirlpool"
+  },
+  {
+    "name": "VOSTROM Public License for Open Source",
+    "licenseId": "VOSTROM"
+  },
+  {
+    "name": "Vovida Software License v1.0",
+    "licenseId": "VSL-1.0"
+  },
+  {
+    "name": "Vim License",
+    "licenseId": "Vim"
+  },
+  {
+    "name": "Vixie Cron License",
+    "licenseId": "Vixie-Cron"
+  },
+  {
+    "name": "W3C Software Notice and License (2002-12-31)",
+    "licenseId": "W3C"
+  },
+  {
+    "name": "W3C Software Notice and License (1998-07-20)",
+    "licenseId": "W3C-19980720"
+  },
+  {
+    "name": "W3C Software Notice and Document License (2015-05-13)",
+    "licenseId": "W3C-20150513"
+  },
+  {
+    "name": "Do What The F*ck You Want To But It's Not My Fault Public License",
+    "licenseId": "WTFNMFPL"
+  },
+  {
+    "name": "Do What The F*ck You Want To Public License",
+    "licenseId": "WTFPL"
+  },
+  {
+    "name": "Sybase Open Watcom Public License 1.0",
+    "licenseId": "Watcom-1.0"
+  },
+  {
+    "name": "Widget Workshop License",
+    "licenseId": "Widget-Workshop"
+  },
+  {
+    "name": "WordNet License",
+    "licenseId": "WordNet"
+  },
+  {
+    "name": "Wsuipa License",
+    "licenseId": "Wsuipa"
+  },
+  {
+    "name": "X11 License",
+    "licenseId": "X11"
+  },
+  {
+    "name": "X11 License Distribution Modification Variant",
+    "licenseId": "X11-distribute-modifications-variant"
+  },
+  {
+    "name": "X11 no permit persons clause",
+    "licenseId": "X11-no-permit-persons"
+  },
+  {
+    "name": "X11 swapped final paragraphs",
+    "licenseId": "X11-swapped"
+  },
+  {
+    "name": "XFree86 License 1.1",
+    "licenseId": "XFree86-1.1"
+  },
+  {
+    "name": "XSkat License",
+    "licenseId": "XSkat"
+  },
+  {
+    "name": "Xdebug License v 1.03",
+    "licenseId": "Xdebug-1.03"
+  },
+  {
+    "name": "Xerox License",
+    "licenseId": "Xerox"
+  },
+  {
+    "name": "Xfig License",
+    "licenseId": "Xfig"
+  },
+  {
+    "name": "X.Net License",
+    "licenseId": "Xnet"
+  },
+  {
+    "name": "Yahoo! Public License v1.0",
+    "licenseId": "YPL-1.0"
+  },
+  {
+    "name": "Yahoo! Public License v1.1",
+    "licenseId": "YPL-1.1"
+  },
+  {
+    "name": "Zope Public License 1.1",
+    "licenseId": "ZPL-1.1"
+  },
+  {
+    "name": "Zope Public License 2.0",
+    "licenseId": "ZPL-2.0"
+  },
+  {
+    "name": "Zope Public License 2.1",
+    "licenseId": "ZPL-2.1"
+  },
+  {
+    "name": "Zed License",
+    "licenseId": "Zed"
+  },
+  {
+    "name": "Zeeff License",
+    "licenseId": "Zeeff"
+  },
+  {
+    "name": "Zend License v2.0",
+    "licenseId": "Zend-2.0"
+  },
+  {
+    "name": "Zimbra Public License v1.3",
+    "licenseId": "Zimbra-1.3"
+  },
+  {
+    "name": "Zimbra Public License v1.4",
+    "licenseId": "Zimbra-1.4"
+  },
+  {
+    "name": "zlib License",
+    "licenseId": "Zlib"
+  },
+  {
+    "name": "Any OSI License",
+    "licenseId": "any-OSI"
+  },
+  {
+    "name": "Any OSI License - Perl Modules",
+    "licenseId": "any-OSI-perl-modules"
+  },
+  {
+    "name": "bcrypt Solar Designer License",
+    "licenseId": "bcrypt-Solar-Designer"
+  },
+  {
+    "name": "SQLite Blessing",
+    "licenseId": "blessing"
+  },
+  {
+    "name": "bzip2 and libbzip2 License v1.0.5",
+    "licenseId": "bzip2-1.0.5"
+  },
+  {
+    "name": "bzip2 and libbzip2 License v1.0.6",
+    "licenseId": "bzip2-1.0.6"
+  },
+  {
+    "name": "check-cvs License",
+    "licenseId": "check-cvs"
+  },
+  {
+    "name": "Checkmk License",
+    "licenseId": "checkmk"
+  },
+  {
+    "name": "copyleft-next 0.3.0",
+    "licenseId": "copyleft-next-0.3.0"
+  },
+  {
+    "name": "copyleft-next 0.3.1",
+    "licenseId": "copyleft-next-0.3.1"
+  },
+  {
+    "name": "curl License",
+    "licenseId": "curl"
+  },
+  {
+    "name": "Common Vulnerability Enumeration ToU License",
+    "licenseId": "cve-tou"
+  },
+  {
+    "name": "diffmark license",
+    "licenseId": "diffmark"
+  },
+  {
+    "name": "David M. Gay dtoa License",
+    "licenseId": "dtoa"
+  },
+  {
+    "name": "dvipdfm License",
+    "licenseId": "dvipdfm"
+  },
+  {
+    "name": "eCos license version 2.0",
+    "licenseId": "eCos-2.0"
+  },
+  {
+    "name": "eGenix.com Public License 1.1.0",
+    "licenseId": "eGenix"
+  },
+  {
+    "name": "Etalab Open License 2.0",
+    "licenseId": "etalab-2.0"
+  },
+  {
+    "name": "fwlw License",
+    "licenseId": "fwlw"
+  },
+  {
+    "name": "gSOAP Public License v1.3b",
+    "licenseId": "gSOAP-1.3b"
+  },
+  {
+    "name": "Generic XTS License",
+    "licenseId": "generic-xts"
+  },
+  {
+    "name": "gnuplot License",
+    "licenseId": "gnuplot"
+  },
+  {
+    "name": "gtkbook License",
+    "licenseId": "gtkbook"
+  },
+  {
+    "name": "hdparm License",
+    "licenseId": "hdparm"
+  },
+  {
+    "name": "hyphen-bulgarian License",
+    "licenseId": "hyphen-bulgarian"
+  },
+  {
+    "name": "iMatix Standard Function Library Agreement",
+    "licenseId": "iMatix"
+  },
+  {
+    "name": "Jove License",
+    "licenseId": "jove"
+  },
+  {
+    "name": "PNG Reference Library License v1 (for libpng 0.5 through 1.6.35)",
+    "licenseId": "libpng-1.6.35"
+  },
+  {
+    "name": "PNG Reference Library version 2",
+    "licenseId": "libpng-2.0"
+  },
+  {
+    "name": "libselinux public domain notice",
+    "licenseId": "libselinux-1.0"
+  },
+  {
+    "name": "libtiff License",
+    "licenseId": "libtiff"
+  },
+  {
+    "name": "libutil David Nugent License",
+    "licenseId": "libutil-David-Nugent"
+  },
+  {
+    "name": "lsof License",
+    "licenseId": "lsof"
+  },
+  {
+    "name": "magaz License",
+    "licenseId": "magaz"
+  },
+  {
+    "name": "mailprio License",
+    "licenseId": "mailprio"
+  },
+  {
+    "name": "man2html License",
+    "licenseId": "man2html"
+  },
+  {
+    "name": "metamail License",
+    "licenseId": "metamail"
+  },
+  {
+    "name": "mpi Permissive License",
+    "licenseId": "mpi-permissive"
+  },
+  {
+    "name": "mpich2 License",
+    "licenseId": "mpich2"
+  },
+  {
+    "name": "mplus Font License",
+    "licenseId": "mplus"
+  },
+  {
+    "name": "ngrep License",
+    "licenseId": "ngrep"
+  },
+  {
+    "name": "pkgconf License",
+    "licenseId": "pkgconf"
+  },
+  {
+    "name": "pnmstitch License",
+    "licenseId": "pnmstitch"
+  },
+  {
+    "name": "psfrag License",
+    "licenseId": "psfrag"
+  },
+  {
+    "name": "psutils License",
+    "licenseId": "psutils"
+  },
+  {
+    "name": "Python ldap License",
+    "licenseId": "python-ldap"
+  },
+  {
+    "name": "radvd License",
+    "licenseId": "radvd"
+  },
+  {
+    "name": "snprintf License",
+    "licenseId": "snprintf"
+  },
+  {
+    "name": "softSurfer License",
+    "licenseId": "softSurfer"
+  },
+  {
+    "name": "ssh-keyscan License",
+    "licenseId": "ssh-keyscan"
+  },
+  {
+    "name": "swrule License",
+    "licenseId": "swrule"
+  },
+  {
+    "name": "threeparttable License",
+    "licenseId": "threeparttable"
+  },
+  {
+    "name": "ulem License",
+    "licenseId": "ulem"
+  },
+  {
+    "name": "w3m License",
+    "licenseId": "w3m"
+  },
+  {
+    "name": "WWL License",
+    "licenseId": "wwl"
+  },
+  {
+    "name": "wxWindows Library License",
+    "licenseId": "wxWindows"
+  },
+  {
+    "name": "xinetd License",
+    "licenseId": "xinetd"
+  },
+  {
+    "name": "xkeyboard-config Zinoviev License",
+    "licenseId": "xkeyboard-config-Zinoviev"
+  },
+  {
+    "name": "xlock License",
+    "licenseId": "xlock"
+  },
+  {
+    "name": "XPP License",
+    "licenseId": "xpp"
+  },
+  {
+    "name": "xzoom License",
+    "licenseId": "xzoom"
+  },
+  {
+    "name": "zlib/libpng License with Acknowledgement",
+    "licenseId": "zlib-acknowledgement"
+  },
+  {
+    "name": "Proprietary",
+    "licenseId": "Proprietary"
+  },
+  {
+    "name": "Others",
+    "licenseId": "Others"
+  }
+]

--- a/cfg/partners.json
+++ b/cfg/partners.json
@@ -1,0 +1,323 @@
+[
+  {
+    "name": "AbsInt Angewandte Informatik GmbH",
+    "aliases": ["AbsInt", "ABS"]
+  },
+  {
+    "name": "Accemic Technologies",
+    "aliases": ["ACCT"]
+  },
+  {
+    "name": "ACP",
+    "aliases": []
+  },
+  {
+    "name": "aicas GmbH",
+    "aliases": ["AIC", "aicas"]
+  },
+  {
+    "name": "ALM",
+    "aliases": []
+  },
+  {
+    "name": "Antmicro SP Zoo",
+    "aliases": ["ANTM", "Antmicro"]
+  },
+  {
+    "name": "ARCELIK",
+    "aliases": []
+  },
+  {
+    "name": "BCA",
+    "aliases": []
+  },
+  {
+    "name": "BEIA",
+    "aliases": []
+  },
+  {
+    "name": "Robert Bosch France SAS",
+    "aliases": ["BOSCH-FR"]
+  },
+  {
+    "name": "Robert Bosch GmbH",
+    "aliases": ["Bosch", "BOSCH-DE"]
+  },
+  {
+    "name": "Barcelona Supercomputing Center",
+    "aliases": ["BSC", "Centro Nacional de Supercomputacion"]
+  },
+  {
+    "name": "BUT",
+    "aliases": []
+  },
+  {
+    "name": "BYK",
+    "aliases": []
+  },
+  {
+    "name": "Commissariat a l’Energie Atomique et aux Energies Alternatives",
+    "aliases": ["CEA"]
+  },
+  {
+    "name": "Codasip GmbH",
+    "aliases": ["CODA", "Codasip"]
+  },
+  {
+    "name": "CONS",
+    "aliases": []
+  },
+  {
+    "name": "CSEM",
+    "aliases": []
+  },
+  {
+    "name": "ETH Zürich",
+    "aliases": ["ETHZ", "ETH", "ETH Zurich"]
+  },
+  {
+    "name": "EXASCALE PERFORMANCE SYSTEMS - EXAPSYS IKE",
+    "aliases": ["EXA"]
+  },
+  {
+    "name": "FENTISS",
+    "aliases": []
+  },
+  {
+    "name": "FORTH",
+    "aliases": []
+  },
+  {
+    "name": "FotoNation",
+    "aliases": []
+  },
+  {
+    "name": "Fraunhofer Gesellschaft zur Förderung der angewandten Forschung e.V.",
+    "aliases": ["FRAUN", "Fraunhofer"]
+  },
+  {
+    "name": "FZI",
+    "aliases": []
+  },
+  {
+    "name": "GSL",
+    "aliases": []
+  },
+  {
+    "name": "HM",
+    "aliases": []
+  },
+  {
+    "name": "Infineon Technologies AG",
+    "aliases": ["IFX", "Infineon Technologies"]
+  },
+  {
+    "name": "Interuniversitair Micro-electronica Centrum",
+    "aliases": ["IMEC"]
+  },
+  {
+    "name": "IMT",
+    "aliases": []
+  },
+  {
+    "name": "INTEL",
+    "aliases": []
+  },
+  {
+    "name": "Klepsydra",
+    "aliases": []
+  },
+  {
+    "name": "LUND",
+    "aliases": []
+  },
+  {
+    "name": "MINRES Technologies GmbH",
+    "aliases": ["MNRS", "MINRES", "MINRES Technologies"]
+  },
+  {
+    "name": "NXP Semiconductors Germany GmbH",
+    "aliases": ["NXP", "NXP-DE"]
+  }
+  {
+    "name": "NXP Semiconductors Austria GmbH & Co. KG",
+    "aliases": ["NXP-AT", "NXP Austria"]
+  },
+  {
+    "name": "NXP-CZ",
+    "aliases": []
+  },
+  {
+    "name": "NXP Semiconductors Romania SRL",
+    "aliases": ["NXP-RO"]
+  },
+  {
+    "name": "NXP Semiconductors France",
+    "aliases": ["NXP-FR"]
+  },
+  {
+    "name": "OFFIS",
+    "aliases": []
+  },
+  {
+    "name": "OpenHW Foundation",
+    "aliases": [
+      "OpenHW",
+      "Eclipse Foundation Europe GmbH",
+      "ECL",
+      "EFE",
+      "Eclipse Foundation",
+      "ECL/OpenHW"
+    ]
+  },
+  {
+    "name": "Others",
+    "aliases": [
+      ""
+    ]
+  },
+  {
+    "name": "Paderborn University / Heinz Nixdorf Institut",
+    "aliases": []
+  },
+  {
+    "name": "Politecnico di Torino",
+    "aliases": ["POLITO"]
+  },
+  {
+    "name": "Politecnico di Torino",
+    "aliases": ["POLIMI"]
+  },
+  {
+    "name": "RAPITA",
+    "aliases": []
+  },
+  {
+    "name": "RPTU",
+    "aliases": []
+  },
+  {
+    "name": "SAL",
+    "aliases": []
+  },
+  {
+    "name": "Semify e.U.",
+    "aliases": ["Semify", "SEM"]
+  },
+  {
+    "name": "Siemens Electronic Design Automation LTd.",
+    "aliases": ["SIEM-IL", "Siemens EDA"]
+  },
+  {
+    "name": "Siemens Aktiengesellschaft Österreich",
+    "aliases": ["SIEM-AT"]
+  },
+  {
+    "name": "SILVACO",
+    "aliases": []
+  },
+  {
+    "name": "SML",
+    "aliases": []
+  },
+  {
+    "name": "SYN",
+    "aliases": []
+  },
+  {
+    "name": "SYSGO GmbH",
+    "aliases": ["SYSGO"]
+  },
+  {
+    "name": "Synthara AG",
+    "aliases": ["SYNT", "Synthara"]
+  },
+  {
+    "name": "Tampere University",
+    "aliases": ["TAU"]
+  },
+  {
+    "name": "TASI",
+    "aliases": []
+  },
+  {
+    "name": "TBD",
+    "aliases": []
+  },
+  {
+    "name": "TDIS",
+    "aliases": []
+  },
+  {
+    "name": "Technische Universität Graz",
+    "aliases": ["TU Graz", "Technical University of Graz"]
+  },
+  {
+    "name": "Technical University of Munich",
+    "aliases": []
+  },
+  {
+    "name": "Technische Universität Darmstadt",
+    "aliases": ["TU Darmstadt", "TUDA"]
+  },
+  {
+    "name": "Technische Universität München",
+    "aliases": ["TUM"]
+  },
+  {
+    "name": "Thales DIS France SAS",
+    "aliases": ["TDIS"]
+  },
+  {
+    "name": "Thales SA",
+    "aliases": ["TRT", "Thales"]
+  },
+  {
+    "name": "TUC",
+    "aliases": []
+  },
+  {
+    "name": "TUI",
+    "aliases": []
+  },
+  {
+    "name": "Universita di Bologna",
+    "aliases": ["UNIBO", "University of Bologna"]
+  },
+  {
+    "name": "UPB",
+    "aliases": []
+  },
+  {
+    "name": "UPV",
+    "aliases": []
+  },
+  {
+    "name": "UZL",
+    "aliases": []
+  },
+  {
+    "name": "VLSI Solution",
+    "aliases": ["VLSI"]
+  },
+  {
+    "name": "Yonga Teknoloji Mikroelektronik Arastirma Gelistirme Tic.",
+    "aliases": ["YNGA", "Yonga Technologies", "Yongatek"]
+  },
+  {
+    "name": "ZHAW",
+    "aliases": []
+  },
+  {
+    "name": "ST Microelectronics SRL",
+    "aliases": ["ST-IT"]
+  },
+  {
+    "name": "Nokia OYJ",
+    "aliases": ["NOKIA", "Nokia"]
+  },
+  {
+    "name": "Cargotec Oyj",
+    "aliases": ["CGT", "Cargotec"]
+  }
+]

--- a/cfg/schema.json
+++ b/cfg/schema.json
@@ -13,8 +13,8 @@
           { "type": "string" }
         ]
       },
-      "Subcategory": { "type": "string" },
       "URL": { "type": "string", "format": "uri" },
+      "IP_Card_URL" : { "type": "string", "format": "uri" },
       "Project": { "type": "string" },
       "WI": {
         "oneOf": [

--- a/editor.html
+++ b/editor.html
@@ -55,7 +55,7 @@
       <h1>Unified RISC-V IP Access Platform</h1>
       <h2>Virtual Repository table editor</h2>
     </section>
-    <section class="editor-intro">
+    <section>
       <p>Use this page to create or edit a Project file (JSON) from the Virtual Repository of the UAP.</p>
       <p>
         You can submit your changes as a GitHub Pull Request to the

--- a/editor.js
+++ b/editor.js
@@ -1,6 +1,7 @@
 /*
  *-------------------------------------------------------------------------------
  * Copyright (C) 2025 philippe
+ * Copyright (C) 2025 Eclipse Foundation
  * 
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -14,6 +15,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   const GITHUB_API_URL = 'https://api.github.com/repos/openhwgroup/tristan-isolde-unified-access-page/contents/ips?ref=main';
   const CATEGORIES_URL = 'cfg/categories.json';
+  const LICENSES_URL = 'cfg/licenses.json';
 
   const fileSelector = document.getElementById('file-selector');
   const loadBtn = document.getElementById('load-file-btn');
@@ -29,6 +31,8 @@ document.addEventListener('DOMContentLoaded', () => {
 
   let currentData = [];
   let allowedCategories = [];
+  let allowedLicenses = [];
+  let allLicensesData = []; // Full license objects with both name and licenseId
   const schemaColumns = ["Name", "Category", "URL", "License", "Status", "Description", "WI", "Partners", "Comment"];
 
   // --- INITIALIZATION ---
@@ -36,6 +40,7 @@ document.addEventListener('DOMContentLoaded', () => {
   async function initialize() {
     await Promise.all([
       loadCategories(),
+      loadLicenses(),
       populateFileSelector()
     ]);
   }
@@ -47,6 +52,18 @@ document.addEventListener('DOMContentLoaded', () => {
     } catch (error) {
       console.error('Failed to load categories:', error);
       alert('Error: Could not load categories configuration.');
+    }
+  }
+
+  async function loadLicenses() {
+    try {
+      const response = await fetch(LICENSES_URL);
+      allLicensesData = await response.json();
+      // Extract licenseId values from the licenses array
+      allowedLicenses = allLicensesData.map(license => license.licenseId);
+    } catch (error) {
+      console.error('Failed to load licenses:', error);
+      alert('Error: Could not load licenses configuration.');
     }
   }
 
@@ -152,6 +169,23 @@ document.addEventListener('DOMContentLoaded', () => {
         return; // Stop the save process
       }
       seenNames.add(name);
+    }
+
+    // Validation of the License field
+    for (let i = 0; i < currentData.length; i++) {
+      const row = currentData[i];
+      const license = (row.License || '').trim();
+
+      // Skip empty licenses (they're allowed)
+      if (!license) continue;
+
+      // Check if license is in the allowed list
+      if (!allowedLicenses.includes(license)) {
+        alert(`Error: Invalid license value "${license}" found in row ${i + 1}.\n` +
+              `Please select a valid license from the dropdown list.\n` +
+              `Valid licenses: ${allowedLicenses.join(', ')}`);
+        return; // Stop the save process
+      }
     }
 
     const outputOrder = ["Name", "URL", "License", "Status", "Description", "Project", "WI", "Partners", "Comment", "Category"];
@@ -275,6 +309,67 @@ document.addEventListener('DOMContentLoaded', () => {
               opt.style.display = opt.textContent.toLowerCase().includes(filterText) ? 'block' : 'none';
             });
           });
+        } else if (key === 'License') {
+          const container = document.createElement('div');
+          container.className = 'license-combobox-container';
+
+          const input = document.createElement('input');
+          input.type = 'text';
+          input.value = Array.isArray(value) ? value.join(', ') : value;
+          input.dataset.index = rowIndex;
+          input.dataset.key = key;
+          container.appendChild(input);
+
+          const dropdown = document.createElement('div');
+          dropdown.className = 'license-dropdown';
+
+          allowedLicenses.forEach(licenseId => {
+            const licenseData = allLicensesData.find(l => l.licenseId === licenseId);
+            const option = document.createElement('div');
+            option.textContent = licenseId;
+            option.className = 'license-option';
+            option.dataset.licenseId = licenseId;
+            option.addEventListener('mousedown', (e) => {
+              e.preventDefault(); // Prevent input from losing focus
+              const currentValues = input.value.split(',').map(s => s.trim()).filter(Boolean);
+              if (!currentValues.includes(licenseId)) {
+                currentValues.push(licenseId);
+                input.value = currentValues.join(', ') + ', '; 
+                // Manually trigger the input event to update the data model
+                input.dispatchEvent(new Event('input', { bubbles: true }));
+                // Set focus and move cursor to the end of the input
+                input.focus();
+                const end = input.value.length;
+                input.setSelectionRange(end, end);
+              }
+            });
+            dropdown.appendChild(option);
+          });
+
+          container.appendChild(dropdown);
+          td.appendChild(container);
+
+          input.addEventListener('focus', () => {
+            dropdown.style.display = 'block';
+          });
+
+          input.addEventListener('blur', () => {
+            // Delay hiding to allow click on dropdown options
+            setTimeout(() => {
+              dropdown.style.display = 'none';
+            }, 150);
+          });
+
+          input.addEventListener('input', () => {
+            const filterText = input.value.split(',').pop().trim().toLowerCase();
+            // Filter by licenseId or license name
+            dropdown.querySelectorAll('.license-option').forEach(opt => {
+              const licenseData = allLicensesData.find(l => l.licenseId === opt.dataset.licenseId);
+              const matchesLicenseId = opt.textContent.toLowerCase().includes(filterText);
+              const matchesName = licenseData && licenseData.name.toLowerCase().includes(filterText);
+              opt.style.display = (matchesLicenseId || matchesName) ? 'block' : 'none';
+            });
+          });
         } else {
           const input = document.createElement('input');
           input.type = 'text';
@@ -335,7 +430,15 @@ document.addEventListener('DOMContentLoaded', () => {
   // Use 'change' for select dropdowns.
   tbody.addEventListener('input', (e) => {
     const target = e.target;
-    if (target.tagName === 'INPUT' || target.tagName === 'SELECT') {
+    if (target.tagName === 'INPUT') {
+      const { index, key } = target.dataset;
+      updateData(parseInt(index, 10), key, target.value);
+    }
+  });
+
+  tbody.addEventListener('change', (e) => {
+    const target = e.target;
+    if (target.tagName === 'SELECT') {
       const { index, key } = target.dataset;
       updateData(parseInt(index, 10), key, target.value);
     }

--- a/scripts/create_licenses_list.py
+++ b/scripts/create_licenses_list.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+
+# -----------------------------------------------------------------------------
+#  Copyright (C) 2026 Eclipse Foundation
+#  
+#  This program and the accompanying materials are made
+#  available under the terms of the Eclipse Public License 2.0
+#  which is available at https://www.eclipse.org/legal/epl-2.0/
+#  
+#  SPDX-License-Identifier: EPL-2.0
+# -----------------------------------------------------------------------------
+#
+# create_licenses_list.py
+
+"""
+Script to create the list of valid licenses, saved at cfg/licenses.json.
+It obtains the latest official SPDX, from its GitHub repo, removing non 
+essential information, and adding custom licenses at the end of the file.
+"""
+
+import json
+import urllib.request
+from pathlib import Path
+
+
+def download_spdx_licenses():
+    """Download SPDX license list from GitHub."""
+    url = "https://raw.githubusercontent.com/spdx/license-list-data/main/json/licenses.json"
+    
+    # Create cfg directory, in case it does not exist
+    cfg_dir = Path(__file__).parent.parent / "cfg"
+    cfg_dir.mkdir(exist_ok=True)
+    
+    # Download the latest public SPDX license list
+    print("Downloading SPDX license list...")
+    with urllib.request.urlopen(url) as response:
+        data = json.loads(response.read().decode('utf-8'))
+    
+    # Extract only the name and licenseId fields from each license
+    licenses = []
+    for item in data.get('licenses', []):
+        filtered_item = {
+            "name": item.get('name'),
+            "licenseId": item.get('licenseId')
+        }
+        licenses.append(filtered_item)
+    
+    # Sort by licenseId for consistent ordering
+    licenses.sort(key=lambda x: x.get('licenseId', ''))
+    
+    # Add custom license types at the end
+    licenses.append({
+        "name": "Proprietary",
+        "licenseId": "Proprietary"
+    })
+    licenses.append({
+        "name": "Others",
+        "licenseId": "Others"
+    })
+
+    # Save to cfg/licenses.json
+    output_path = cfg_dir / "licenses.json"
+    with open(output_path, 'w', encoding='utf-8') as f:
+        json.dump(licenses, f, indent=2, ensure_ascii=False)
+
+    print(f"Saved {len(licenses)} licenses to {output_path}")
+    return len(licenses)
+
+
+if __name__ == "__main__":
+    download_spdx_licenses()

--- a/style.css
+++ b/style.css
@@ -1,6 +1,7 @@
 /*
  *-------------------------------------------------------------------------------
  * Copyright (C) 2025 philippe
+ * Copyright (C) 2025 Eclipse Foundation
  * 
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -69,13 +70,7 @@ header {
   padding: 0.85rem 1.5rem;
 }
 
-.nav-logo-text {
-  font-weight: 600;
-  letter-spacing: 0.04em;
-  font-size: 1rem;
-  text-transform: uppercase;
-  color: #1b2b3a;
-}
+
 
 nav ul {
   list-style: none;
@@ -436,30 +431,6 @@ select {
     text-overflow: ellipsis;
   }
 }
-/* Allow table to stretch full width across the window */
-.table-fullwidth {
-  width: 100vw;              /* full viewport width */
-  position: relative;
-  left: 50%;
-  right: 50%;
-  margin-left: -50vw;        /* shift to the left edge */
-  margin-right: -50vw;       /* shift to the right edge */
-  padding-left: 1.5rem;      /* match site padding */
-  padding-right: 1.5rem;
-  box-sizing: border-box;
-}
-
-/* Medium mode: table takes 80% of the page */
-.table-medium {
-  max-width: 85%;
-  margin: 0 auto;   /* centers the table */
-}
-
-/* Smaller variant if needed: 70% */
-.table-narrow {
-  max-width: 70%;
-  margin: 0 auto;
-}
 /* Make the table area align to the window, not to <main> */
 .table-viewport {
   width: 100vw;                 /* full viewport width */
@@ -472,28 +443,31 @@ select {
   box-sizing: border-box;
 }
 
-/* Inner container: centered, max 1500px */
 .table-fixed {
-  max-width: 1500px;            /* never wider than 1200px */
-  width: 100%;                  /* but fluid under 1200px */
-  margin: 0 auto;               /* centered inside the viewport band */
+  max-width: none;              /* no width limit */
+  width: 100%;                  /* use all available width */
+  margin: 0;                    /* no centering needed */
+  min-height: 1000px;
 }
 
-/* =========================================================
-   Search bar & floating settings panel
-   ========================================================= */
 
-/* Container for search bar and settings button */
 .search-and-settings-container {
+  width: 100vw;
   display: grid;
   grid-template-columns: 1fr auto;
   position: relative;
   gap: 10px;
   align-items: center;
   margin-bottom: 10px;
+  left: 50%;
+  right: 50%;
+  margin-left: -50vw;           /* pull to the left edge of the window */
+  margin-right: -50vw;          /* pull to the right edge of the window */
+  padding: 0 1.5rem;            /* same side padding as the site */
+  box-sizing: border-box;
 }
 
-#search-input {
+.search-and-settings-container #search-input {
   width: 100%;
   padding: 10px;
   font-size: 1rem;
@@ -502,8 +476,7 @@ select {
   background-color: #ffffff;
 }
 
-/* Settings toggle button */
-#settings-toggle-btn {
+.search-and-settings-container #settings-toggle-btn {
   background: #fff;
   border: 1px solid #ccc;
   border-radius: 6px;
@@ -517,11 +490,10 @@ select {
   justify-content: center;
 }
 
-/* Floating settings panel */
-.floating-panel {
+.search-and-settings-container .floating-panel {
   position: absolute;
   top: calc(100% + 10px);
-  right: 15px;
+  right: 0;
   width: 320px;
   background: #fff;
   border: 1px solid #ccc;
@@ -727,13 +699,13 @@ body.editor-page #data-table tr:hover .row-actions-container {
 }
 
 /* Category combobox in editor */
-.category-combobox-container {
+.category-combobox-container, .license-combobox-container {
   position: relative;
   width: 100%;
   height: 100%;
 }
 
-.category-dropdown {
+.category-dropdown, .license-dropdown {
   display: none;
   position: absolute;
   top: 100%;
@@ -748,17 +720,18 @@ body.editor-page #data-table tr:hover .row-actions-container {
   box-shadow: 0 4px 8px rgba(0,0,0,0.1);
 }
 
-.category-option {
+.category-option, .license-option {
   padding: 10px 14px;
   cursor: pointer;
   font-size: 0.95rem;
 }
 
-.category-option:hover {
+.category-option:hover, .license-option:hover {
   background-color: #eef6ff;
 }
 
-body.editor-page #data-table .category-combobox-container input {
+body.editor-page #data-table .category-combobox-container input, 
+body.editor-page #data-table .license-combobox-container input {
   border-bottom: 1px solid rgba(15,23,42,0.06);
 }
 

--- a/unified-access.html
+++ b/unified-access.html
@@ -46,13 +46,8 @@
 	    </nav>
 	  </div>
 	</header>
-
-  <!-- Page content: search + settings + table -->
   <main>
-    <section class="hero">
-      <img src="images/logo_unified-riscv.png" alt="Unified RISC-V Logo" />
-      <h1>Unified RISC-V IP Access Platform</h1>
-    </section>
+    <!-- Search and Settings div -->
     <div class="search-and-settings-container" style="position: relative;">
       <input
         type="text"
@@ -99,26 +94,28 @@
       </div>
     </div>
 
-   <div class="table-viewport">
-	  <div class="table-container table-fixed">
-	    <table id="data-table">
-	      <thead></thead>
-	      <tbody></tbody>
-	    </table>
+    <!-- Platform Table div-->
+    <div class="table-viewport">
+      <div class="table-container table-fixed">
+        <table id="data-table">
+          <thead></thead>
+          <tbody></tbody>
+        </table>
+      </div>
 	  </div>
-	</div>
-  <!-- Sponsors -->
-	<section id="sponsors" class="sponsors">
-	  <h2 align="center">Supported by</h2>
-	  <div class="sponsor-logos">
-	    <a href="https://tristan-project.eu/" target="_blank">
-	      <img src="images/tristan-logo.png" alt="TRISTAN Project" class="sponsor-logo">
-	    </a>
-	    <a href="https://isolde-project.eu/" target="_blank">
-	      <img src="images/isolde-logo.png" alt="ISOLDE Project" class="sponsor-logo">
-	    </a>
-	  </div>
-	</section>
+
+    <!-- Sponsors -->
+    <section id="sponsors" class="sponsors">
+      <h2 align="center">Supported by</h2>
+      <div class="sponsor-logos">
+        <a href="https://tristan-project.eu/" target="_blank">
+          <img src="images/tristan-logo.png" alt="TRISTAN Project" class="sponsor-logo">
+        </a>
+        <a href="https://isolde-project.eu/" target="_blank">
+          <img src="images/isolde-logo.png" alt="ISOLDE Project" class="sponsor-logo">
+        </a>
+      </div>
+    </section>
   </main>
 
   <script src="script.js"></script>


### PR DESCRIPTION
- Update of categories list according to latest vote by the VRTG (03/26) on cfg/categories.json.
- Removal of the Subcategory field from the schema file, as it is decided that the UAP will not implement subcategories direcly, using a flat approach.
- Creation of a "IP_Card_URL" on the schema file, to reference of future IP Card files, one for each IP.
- Creation of a list of valid licenses on cfg/licenses.json, to be used on the validation of the License field for each IP.
- Creation of a preliminary list of Project Partners on cfg/partners.json, to help future Projects assign IPs to existing Project Partners.
- Validation of Licenses values, from the values on cfg/licenses.json, on the Editor page
- Increasing the size of the IPs table of the Platform/Unified-Access page, making it to use the full visible width again.
- Cleanup of some unused CSS classes